### PR TITLE
fix: options parser fixes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,13 +16,11 @@ var m = module.exports = function (options, callback) {
         debuggingHelp = '',
         cp;
 
-//        m.DEBUG = true;
-
     // set the options, skipping undefined options
     if(options.width) scriptArgs = scriptArgs.concat(['--width', options.width]);
     if(options.height) scriptArgs = scriptArgs.concat(['--height', options.height]);
-    scriptArgs.push(options.url);
-    scriptArgs.push(options.css);
+    scriptArgs.push(options.url || '');
+    scriptArgs.push(options.css || '');
 
     cp = spawn(phantomJsBinPath, [configString, script].concat(scriptArgs));
 

--- a/lib/options-parser.js
+++ b/lib/options-parser.js
@@ -1,12 +1,13 @@
 /*
-parser for the script - can be used both for the standalone node binary and the phantomjs script
-*/
+ * parser for the script - can be used both for the standalone node binary and the phantomjs script
+ */
+
 /*jshint unused:false*/
 
 var usageString = '[--width <width>] [--height <height>] <url> <main.css>';
 
 function buildError(msg, problemToken, args) {
-    var error = new Error( msg  + problemToken);
+    var error = new Error(msg + problemToken);
     error.token = problemToken;
     error.args = args;
     throw error;
@@ -17,25 +18,25 @@ function buildError(msg, problemToken, args) {
 // throws an error on wrong options or parsing error
 function parseOptions(argsOriginal) {
     var args = argsOriginal.slice(0),
-    validOptions = ['--width', '--height'],
-    parsed = {},
-    val,
-    len = args.length,
-    optIndex,
-    option;
+        validOptions = ['--width', '--height'],
+        parsed = {},
+        val,
+        len = args.length,
+        optIndex,
+        option;
 
-    if(len < 2 ) buildError('Invalid number of arguments', args, args);
+    if (len < 2) buildError('Invalid number of arguments', args, args);
 
-    while(args.length > 2 && args[0].match(/^(--width|--height)$/)) {
+    while (args.length > 2 && args[0].match(/^(--width|--height)$/)) {
         optIndex = validOptions.indexOf(args[0]);
-        if(optIndex === -1) buildError('Logic/Parsing error ', args[0], args);
+        if (optIndex === -1) buildError('Logic/Parsing error ', args[0], args);
 
         // lose the dashes
         option = validOptions[optIndex].slice(2);
         val = args[1];
 
         parsed[option] = parseInt(val, 10);
-        if(isNaN(parsed[option])) buildError('Parsing error when parsing ', val, args);
+        if (isNaN(parsed[option])) buildError('Parsing error when parsing ', val, args);
 
         // remove the two parsed arguments from the list
         args = args.slice(2);
@@ -44,16 +45,21 @@ function parseOptions(argsOriginal) {
     parsed.url = args[0];
     parsed.css = args[1];
 
-    if( ! parsed.url.match(/https?:\/\//) ) {
-      buildError('Invalid url: ', parsed.url, args);
+    if (!parsed.url) {
+        buildError('Missing url/path to html file', '', args);
     }
+
+    if (!parsed.css) {
+        buildError('Missing css file', '', args);
+    }
+
 
     return parsed;
 }
 
-if(typeof module !== 'undefined') {
+if (typeof module !== 'undefined') {
     module.exports = exports = {
-        parse : parseOptions,
-        usage : usageString
+        parse: parseOptions,
+        usage: usageString
     };
 }

--- a/lib/options-parser.js
+++ b/lib/options-parser.js
@@ -25,7 +25,7 @@ function parseOptions(argsOriginal) {
         optIndex,
         option;
 
-    if (len < 2) buildError('Invalid number of arguments', args, args);
+    if (len < 2) buildError('Not enough arguments, ', args);
 
     while (args.length > 2 && args[0].match(/^(--width|--height)$/)) {
         optIndex = validOptions.indexOf(args[0]);

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -366,8 +366,14 @@ if (standaloneMode) {
 try {
 	options = parse(system.args.slice(1));
 } catch (ex) {
-	debug('Caught error parsing arguments: ' + ex.message);
-	errorlog('Usage: phantomjs penthouse.js ' + usage);
+
+    errorlog('Caught error parsing arguments: ' + ex.message);
+
+    // the usage string does not make sense to show if running via Node
+    if(standaloneMode) {
+        errorlog('\nUsage: phantomjs penthouse.js ' + usage);
+    }
+
 	phantom.exit(1);
 }
 

--- a/lib/phantomjs/usage.txt
+++ b/lib/phantomjs/usage.txt
@@ -1,7 +1,7 @@
 
 
 USAGE:
-    phantomjs penthouse.js [CSS file] [URL to page] > [critical path CSS file]
+    phantomjs penthouse.js [options] <URL to page> <CSS file>
     Options:
     --width <width>      The viewport width in pixels. Defaults to 1300 
     --height <height>    The viewport height in pixels. Defaults to 900 

--- a/penthouse.js
+++ b/penthouse.js
@@ -22,14 +22,15 @@ DEPENDENCIES
 
 (function() { "use strict"; 
 /*
-parser for the script - can be used both for the standalone node binary and the phantomjs script
-*/
+ * parser for the script - can be used both for the standalone node binary and the phantomjs script
+ */
+
 /*jshint unused:false*/
 
 var usageString = '[--width <width>] [--height <height>] <url> <main.css>';
 
 function buildError(msg, problemToken, args) {
-    var error = new Error( msg  + problemToken);
+    var error = new Error(msg + problemToken);
     error.token = problemToken;
     error.args = args;
     throw error;
@@ -40,25 +41,25 @@ function buildError(msg, problemToken, args) {
 // throws an error on wrong options or parsing error
 function parseOptions(argsOriginal) {
     var args = argsOriginal.slice(0),
-    validOptions = ['--width', '--height'],
-    parsed = {},
-    val,
-    len = args.length,
-    optIndex,
-    option;
+        validOptions = ['--width', '--height'],
+        parsed = {},
+        val,
+        len = args.length,
+        optIndex,
+        option;
 
-    if(len < 2 ) buildError('Invalid number of arguments', args, args);
+    if (len < 2) buildError('Invalid number of arguments', args, args);
 
-    while(args.length > 2 && args[0].match(/^(--width|--height)$/)) {
+    while (args.length > 2 && args[0].match(/^(--width|--height)$/)) {
         optIndex = validOptions.indexOf(args[0]);
-        if(optIndex === -1) buildError('Logic/Parsing error ', args[0], args);
+        if (optIndex === -1) buildError('Logic/Parsing error ', args[0], args);
 
         // lose the dashes
         option = validOptions[optIndex].slice(2);
         val = args[1];
 
         parsed[option] = parseInt(val, 10);
-        if(isNaN(parsed[option])) buildError('Parsing error when parsing ', val, args);
+        if (isNaN(parsed[option])) buildError('Parsing error when parsing ', val, args);
 
         // remove the two parsed arguments from the list
         args = args.slice(2);
@@ -67,19 +68,25 @@ function parseOptions(argsOriginal) {
     parsed.url = args[0];
     parsed.css = args[1];
 
-    if( ! parsed.url.match(/https?:\/\//) ) {
-      buildError('Invalid url: ', parsed.url, args);
+    if (!parsed.url) {
+        buildError('Missing url/path to html file', '', args);
     }
+
+    if (!parsed.css) {
+        buildError('Missing css file', '', args);
+    }
+
 
     return parsed;
 }
 
-if(typeof module !== 'undefined') {
+if (typeof module !== 'undefined') {
     module.exports = exports = {
-        parse : parseOptions,
-        usage : usageString
+        parse: parseOptions,
+        usage: usageString
     };
 }
+
 /*
 module for removing unused fontface rules - can be used both for the standalone node binary and the phantomjs script
 */
@@ -139,7 +146,7 @@ function unusedFontfaceRemover (css){
   }
 
   return css;
-};
+}
 
 
 
@@ -189,7 +196,7 @@ function cssPreformatter (css){
   }
 
   return css;
-};
+}
 
 if(typeof module !== 'undefined') {
     module.exports = cssPreformatter;

--- a/penthouse.js
+++ b/penthouse.js
@@ -6,7 +6,7 @@ License: MIT
 Version: 0.3.0-rc
 
 USAGE:
-    phantomjs penthouse.js [CSS file] [URL to page] > [critical path CSS file]
+    phantomjs penthouse.js [options] <URL to page> <CSS file>
     Options:
     --width <width>      The viewport width in pixels. Defaults to 1300 
     --height <height>    The viewport height in pixels. Defaults to 900 
@@ -146,7 +146,7 @@ function unusedFontfaceRemover (css){
   }
 
   return css;
-}
+};
 
 
 
@@ -196,7 +196,7 @@ function cssPreformatter (css){
   }
 
   return css;
-}
+};
 
 if(typeof module !== 'undefined') {
     module.exports = cssPreformatter;
@@ -570,8 +570,14 @@ if (standaloneMode) {
 try {
 	options = parse(system.args.slice(1));
 } catch (ex) {
-	debug('Caught error parsing arguments: ' + ex.message);
-	errorlog('Usage: phantomjs penthouse.js ' + usage);
+
+    errorlog('Caught error parsing arguments: ' + ex.message);
+
+    // the usage string does not make sense to show if running via Node
+    if(standaloneMode) {
+        errorlog('\nUsage: phantomjs penthouse.js ' + usage);
+    }
+
 	phantom.exit(1);
 }
 

--- a/test/css-preformatter-test.js
+++ b/test/css-preformatter-test.js
@@ -1,0 +1,36 @@
+var path = require('path');
+var fs = require('fs');
+var read = fs.readFileSync;
+var css = require('css');
+var chai = require('chai');
+var should = chai.should();// extends Object.prototype (so ignore unused warnings)
+
+
+it('should preformat css (rm comments etc)', function (done) {
+    var cssPreformatCssFilePath = path.join(__dirname, 'static-server', 'preformat-css--remove.css'),
+        cssPreformatCss = read(cssPreformatCssFilePath).toString(),
+        cssPreformatter = require('../lib/phantomjs/css-preformatter.js');
+
+    var result = cssPreformatter(cssPreformatCss);
+
+    try {
+        var resultAst = css.parse(result);
+        var orgAst = css.parse(cssPreformatCss);
+        //with comments stripped out, fewer 'rules' (comments included) in AST
+        resultAst.stylesheet.rules.should.have.length.lessThan(orgAst.stylesheet.rules.length);
+        //but except for comments, (also inside declarations), everything should be the same
+        var orgAstRulesExceptComments = orgAst.stylesheet.rules.filter(function (rule) {
+            if (typeof rule.declarations !== "undefined") {
+                rule.declarations = rule.declarations.filter(function (declaration) {
+                    return declaration.type !== "comment"
+                })
+            }
+            return rule.type !== "comment";
+        });
+        orgAstRulesExceptComments.should.eql(resultAst.stylesheet.rules);
+
+        done();
+    } catch (ex) {
+        done(ex);
+    }
+});

--- a/test/full-tests.js
+++ b/test/full-tests.js
@@ -1,332 +1,329 @@
 var penthouse = require('../lib/'),
-	chai = require('chai'),
-  should = chai.should(),
-	css = require('css'),
-	fs = require('fs'),
-	read = fs.readFileSync,
-	path = require('path'),
-	async = require('async'),
-	glob = require('glob');
+    chai = require('chai'),
+    should = chai.should(),// extends Object.prototype (so ignore unused warnings)
+    css = require('css'),
+    fs = require('fs'),
+    read = fs.readFileSync,
+    path = require('path');
 
 //penthouse.DEBUG = true;
 
-describe('penthouse functionality tests', function() {
-	var page1cssPath = path.join(__dirname, 'static-server', 'page1.css'),
-		sharedCssFilePath = path.join(__dirname, 'static-server', 'shared.css'),
-		originalCss = read(page1cssPath).toString(),
-		page1, server, port;
+describe('penthouse functionality tests', function () {
+    var page1cssPath = path.join(__dirname, 'static-server', 'page1.css'),
+        page1, server, port;
 
-	// phantomjs takes a while to start up
-	this.timeout(5000);
+    // phantomjs takes a while to start up
+    this.timeout(5000);
 
-	before(function(done) {
-		startServer(function(instance, serverPort) {
-			server = instance;
-			port = serverPort;
-			page1 = ('http://localhost:' + port + '/page1.html');
-			done();
-		});
-	});
+    before(function (done) {
+        startServer(function (instance, serverPort) {
+            server = instance;
+            port = serverPort;
+            page1 = ('http://localhost:' + port + '/page1.html');
+            done();
+        });
+    });
 
-	after(function(done) {
-		server.close();
-		done();
-	});
+    after(function (done) {
+        server.close();
+        done();
+    });
 
-	it('should save css to a file', function(done) {
-		penthouse({
-			url: page1,
-			css: page1cssPath
-		}, function(err, result) {
-			if (err) {
-				done(err);
-				return;
-			}
-			try {
-				css.parse(result);
-				done();
-			} catch (ex) {
-				done(ex);
-			}
-		});
-	});
+    it('should save css to a file', function (done) {
+        penthouse({
+            url: page1,
+            css: page1cssPath
+        }, function (err, result) {
+            if (err) {
+                done(err);
+                return;
+            }
+            try {
+                css.parse(result);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
 
-	it('should match exactly the css in the yeoman test', function(done) {
-    var yeomanFullCssFilePath = path.join(__dirname, 'static-server', 'yeoman-full.css'),
-        yeomanFullCss = read(yeomanFullCssFilePath).toString(),
-        yeomanExpectedCssFilePath = path.join(__dirname, 'static-server', 'yeoman-small-expected.css'),
-        yeomanExpectedCss = read(yeomanExpectedCssFilePath).toString();
+    it('should match exactly the css in the yeoman test', function (done) {
+        var yeomanFullCssFilePath = path.join(__dirname, 'static-server', 'yeoman-full.css'),
+            yeomanExpectedCssFilePath = path.join(__dirname, 'static-server', 'yeoman-small-expected.css'),
+            yeomanExpectedCss = read(yeomanExpectedCssFilePath).toString();
 
-    penthouse({
-        url: 'http://localhost:' + port + '/yeoman.html',
-        css: yeomanFullCssFilePath,
-        width: 320,
-        height: 70
-    }, function (err, result) {
-        if(err) { done(err); }
+        penthouse({
+            url: 'http://localhost:' + port + '/yeoman.html',
+            css: yeomanFullCssFilePath,
+            width: 320,
+            height: 70
+        }, function (err, result) {
+            if (err) {
+                done(err);
+            }
+            try {
+                var resultAst = css.parse(result);
+                var expectedAst = css.parse(yeomanExpectedCss);
+                resultAst.should.eql(expectedAst);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+
+        });
+    });
+
+    it('should keep :before, :after rules (because el above fold)', function (done) {
+        var pusedoRemainCssFilePath = path.join(__dirname, 'static-server', 'psuedo--remain.css'),
+            pusedoRemainCss = read(pusedoRemainCssFilePath).toString();
+
+        penthouse({
+            url: page1,
+            css: pusedoRemainCssFilePath
+        }, function (err, result) {
+            try {
+                var resultAst = css.parse(result);
+                var orgAst = css.parse(pusedoRemainCss);
+                resultAst.should.eql(orgAst);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+
+
+    it('should remove :hover, :active, etc rules - always', function (done) {
+        var pusedoRemoveCssFilePath = path.join(__dirname, 'static-server', 'psuedo--remove.css');
+
+        penthouse({
+            url: page1,
+            css: pusedoRemoveCssFilePath
+        }, function (err, result) {
+            try {
+                result.trim().should.equal('');
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+
+        });
+    });
+
+
+    /*==@-rule handling==*/
+
+    /* - Case 0 : Non nested @-rule [REMAIN]
+     (@charset, @import, @namespace)
+     */
+    it('should keep complete case 0 @-rules (@import, @charset, @namespace)', function (done) {
+        var atRuleCase0RemainCssFilePath = path.join(__dirname, 'static-server', 'at-rule-case-0--remain.css'),
+            atRuleCase0RemainCss = read(atRuleCase0RemainCssFilePath).toString();
+
+        penthouse({
+            url: page1,
+            css: atRuleCase0RemainCssFilePath
+        }, function (err, result) {
+            try {
+                var resultAst = css.parse(result);
+                var orgAst = css.parse(atRuleCase0RemainCss);
+                resultAst.should.eql(orgAst);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+
+        });
+    });
+
+
+    /*	- Case 1: @-rule with CSS properties inside [REMAIN]
+     (NOTE: @font-face is removed later in code, unless it is used.
+     Therefor currently this test has to include CSS 'using' the @font-face)
+     */
+    it('should keep complete case 1 @-rules (@font-face)', function (done) {
+        var atRuleCase1RemainCssFilePath = path.join(__dirname, 'static-server', 'at-rule-case-1--remain.css'),
+            atRuleCase1RemainCss = read(atRuleCase1RemainCssFilePath).toString();
+
+        penthouse({
+            url: page1,
+            css: atRuleCase1RemainCssFilePath
+        }, function (err, result) {
+            try {
+                var resultAst = css.parse(result);
+                var orgAst = css.parse(atRuleCase1RemainCss);
+                resultAst.should.eql(orgAst);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+
+        });
+    });
+
+    /*Case 2: @-rule with CSS properties inside [REMOVE]
+     @page
+     */
+    it('should remove complete case 2 @-rules (@page..)', function (done) {
+        var atRuleCase2RemoveCssFilePath = path.join(__dirname, 'static-server', 'at-rule-case-4--remove.css');
+
+        penthouse({
+            url: page1,
+            css: atRuleCase2RemoveCssFilePath
+        }, function (err, result) {
+            try {
+                result.trim().should.equal('');
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+
+        });
+    });
+
+    /*Case 3: @-rule with full CSS (rules) inside [REMAIN]
+     @media, @document, @supports..
+     */
+    it('should keep case 3 @-rules (@media, @document..)', function (done) {
+        var atRuleCase3RemainCssFilePath = path.join(__dirname, 'static-server', 'at-rule-case-3--remain.css'),
+            atRuleCase3RemainCss = read(atRuleCase3RemainCssFilePath).toString();
+
+        penthouse({
+            url: page1,
+            css: atRuleCase3RemainCssFilePath
+        }, function (err, result) {
+            try {
+                var resultAst = css.parse(result);
+                var orgAst = css.parse(atRuleCase3RemainCss);
+                resultAst.should.eql(orgAst);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+
+        });
+    });
+
+    /*Case 4: @-rule with full CSS (rules) inside [REMOVE]
+     - @keyframes, @media print|speech|arual
+     */
+    it('should remove case 4 @-rules (@media print|speech, @keyframes..)', function (done) {
+        var atRuleCase4RemoveCssFilePath = path.join(__dirname, 'static-server', 'at-rule-case-4--remove.css');
+
+        penthouse({
+            url: page1,
+            css: atRuleCase4RemoveCssFilePath
+        }, function (err, result) {
+            try {
+                result.trim().should.equal('');
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+
+        });
+    });
+
+
+    it('should keep self clearing rules when needed to stay outside the fold', function (done) {
+        var clearSelfRemainCssFilePath = path.join(__dirname, 'static-server', 'clearSelf--remain.css'),
+            clearSelfRemainCss = read(clearSelfRemainCssFilePath).toString();
+
+        penthouse({
+            url: 'http://localhost:' + port + '/clearSelf.html',
+            css: clearSelfRemainCssFilePath
+        }, function (err, result) {
+            try {
+                var resultAst = css.parse(result);
+                var orgAst = css.parse(clearSelfRemainCss);
+                resultAst.should.eql(orgAst);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+
+        });
+    });
+
+    /* non core (non breaking) functionality tests */
+    it('should remove empty rules', function (done) {
+        var emptyRemoveCssFilePath = path.join(__dirname, 'static-server', 'empty-rules--remove.css');
+
+        penthouse({
+            url: page1,
+            css: emptyRemoveCssFilePath
+        }, function (err, result) {
+            try {
+                result.trim().should.equal('');
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+
+        });
+    });
+
+    it('should remove @fontface rule, because it is not used', function (done) {
+        var fontFaceRemoveCssFilePath = path.join(__dirname, 'static-server', 'fontface--remove.css'),
+            fontFaceRemoveCss = read(fontFaceRemoveCssFilePath).toString(),
+            ffRemover = require('../lib/phantomjs/unused-fontface-remover.js');
+
+        var result = ffRemover(fontFaceRemoveCss);
+
         try {
             var resultAst = css.parse(result);
-            var expectedAst = css.parse(yeomanExpectedCss);
-            resultAst.should.eql(expectedAst);
+            var orgAst = css.parse(fontFaceRemoveCss);
+            resultAst.stylesheet.rules.should.have.length.lessThan(orgAst.stylesheet.rules.length);
             done();
         } catch (ex) {
             done(ex);
         }
 
     });
-  });
 
-	it('should keep :before, :after rules (because el above fold)', function(done) {
-		var pusedoRemainCssFilePath = path.join(__dirname, 'static-server', 'psuedo--remain.css'),
-			pusedoRemainCss = read(pusedoRemainCssFilePath).toString();
+    it('should preformat css (rm comments etc)', function (done) {
+        var cssPreformatCssFilePath = path.join(__dirname, 'static-server', 'preformat-css--remove.css'),
+            cssPreformatCss = read(cssPreformatCssFilePath).toString(),
+            cssPreformatter = require('../lib/phantomjs/css-preformatter.js');
 
-		penthouse({
-			url: page1,
-			css: pusedoRemainCssFilePath
-		}, function(err, result) {
-			try {
-				var resultAst = css.parse(result);
-				var orgAst = css.parse(pusedoRemainCss);
-				resultAst.should.eql(orgAst);
-				done();
-			} catch (ex) {
-				done(ex);
-			}
-		});
-	});
+        var result = cssPreformatter(cssPreformatCss);
 
+        try {
+            var resultAst = css.parse(result);
+            var orgAst = css.parse(cssPreformatCss);
+            //with comments stripped out, fewer 'rules' (comments included) in AST
+            resultAst.stylesheet.rules.should.have.length.lessThan(orgAst.stylesheet.rules.length);
+            //but except for comments, (also inside declarations), everything should be the same
+            var orgAstRulesExceptComments = orgAst.stylesheet.rules.filter(function (rule) {
+                if (typeof rule.declarations !== "undefined") {
+                    rule.declarations = rule.declarations.filter(function (declaration) {
+                        return declaration.type !== "comment"
+                    })
+                }
+                return rule.type !== "comment";
+            })
+            orgAstRulesExceptComments.should.eql(resultAst.stylesheet.rules);
 
-	it('should remove :hover, :active, etc rules - always', function(done) {
-		var pusedoRemoveCssFilePath = path.join(__dirname, 'static-server', 'psuedo--remove.css');
+            done();
+        } catch (ex) {
+            done(ex);
+        }
 
-		penthouse({
-			url: page1,
-			css: pusedoRemoveCssFilePath
-		}, function(err, result) {
-			try {
-				result.trim().should.equal('');
-				done();
-			} catch (ex) {
-				done(ex);
-			}
-
-		});
-	});
-
-
-	/*==@-rule handling==*/
-
-	/* - Case 0 : Non nested @-rule [REMAIN]
-		(@charset, @import, @namespace)
-	*/
-	it('should keep complete case 0 @-rules (@import, @charset, @namespace)', function(done) {
-		var atRuleCase0RemainCssFilePath = path.join(__dirname, 'static-server', 'at-rule-case-0--remain.css'),
-			atRuleCase0RemainCss = read(atRuleCase0RemainCssFilePath).toString();
-
-		penthouse({
-			url: page1,
-			css: atRuleCase0RemainCssFilePath
-		}, function(err, result) {
-			try {
-				var resultAst = css.parse(result);
-				var orgAst = css.parse(atRuleCase0RemainCss);
-				resultAst.should.eql(orgAst);
-				done();
-			} catch (ex) {
-				done(ex);
-			}
-
-		});
-	});
-
-
-	/*	- Case 1: @-rule with CSS properties inside [REMAIN]
-		(NOTE: @font-face is removed later in code, unless it is used.
-				Therefor currently this test has to include CSS 'using' the @font-face)
-	*/
-	it('should keep complete case 1 @-rules (@font-face)', function(done) {
-		var atRuleCase1RemainCssFilePath = path.join(__dirname, 'static-server', 'at-rule-case-1--remain.css'),
-			atRuleCase1RemainCss = read(atRuleCase1RemainCssFilePath).toString();
-
-		penthouse({
-			url: page1,
-			css: atRuleCase1RemainCssFilePath
-		}, function(err, result) {
-			try {
-				var resultAst = css.parse(result);
-				var orgAst = css.parse(atRuleCase1RemainCss);
-				resultAst.should.eql(orgAst);
-				done();
-			} catch (ex) {
-				done(ex);
-			}
-
-		});
-	});
-
-	/*Case 2: @-rule with CSS properties inside [REMOVE]
-		@page
-	*/
-  it('should remove complete case 2 @-rules (@page..)', function(done) {
-		var atRuleCase2RemoveCssFilePath = path.join(__dirname, 'static-server', 'at-rule-case-4--remove.css');
-
-		penthouse({
-			url: page1,
-			css: atRuleCase2RemoveCssFilePath
-		}, function(err, result) {
-			try {
-				result.trim().should.equal('');
-				done();
-			} catch (ex) {
-				done(ex);
-			}
-
-		});
-	});
-
-	/*Case 3: @-rule with full CSS (rules) inside [REMAIN]
-		@media, @document, @supports..
-	*/
-	it('should keep case 3 @-rules (@media, @document..)', function(done) {
-		var atRuleCase3RemainCssFilePath = path.join(__dirname, 'static-server', 'at-rule-case-3--remain.css'),
-			atRuleCase3RemainCss = read(atRuleCase3RemainCssFilePath).toString();
-
-		penthouse({
-			url: page1,
-			css: atRuleCase3RemainCssFilePath
-		}, function(err, result) {
-			try {
-				var resultAst = css.parse(result);
-				var orgAst = css.parse(atRuleCase3RemainCss);
-				resultAst.should.eql(orgAst);
-				done();
-			} catch (ex) {
-				done(ex);
-			}
-
-		});
-	});
-
-	/*Case 4: @-rule with full CSS (rules) inside [REMOVE]
-		- @keyframes, @media print|speech|arual
-	*/
-	it('should remove case 4 @-rules (@media print|speech, @keyframes..)', function(done) {
-		var atRuleCase4RemoveCssFilePath = path.join(__dirname, 'static-server', 'at-rule-case-4--remove.css');
-
-		penthouse({
-			url: page1,
-			css: atRuleCase4RemoveCssFilePath
-		}, function(err, result) {
-			try {
-				result.trim().should.equal('');
-				done();
-			} catch (ex) {
-				done(ex);
-			}
-
-		});
-	});
-
-
-	it('should keep self clearing rules when needed to stay outside the fold', function(done) {
-		var clearSelfRemainCssFilePath = path.join(__dirname, 'static-server', 'clearSelf--remain.css'),
-			clearSelfRemainCss = read(clearSelfRemainCssFilePath).toString();
-
-		penthouse({
-			url: 'http://localhost:' + port + '/clearSelf.html',
-			css: clearSelfRemainCssFilePath
-		}, function(err, result) {
-			try {
-				var resultAst = css.parse(result);
-				var orgAst = css.parse(clearSelfRemainCss);
-				resultAst.should.eql(orgAst);
-				done();
-			} catch (ex) {
-				done(ex);
-			}
-
-		});
-	});
-
-	/* non core (non breaking) functionality tests */
-	it('should remove empty rules', function(done) {
-		var emptyRemoveCssFilePath = path.join(__dirname, 'static-server', 'empty-rules--remove.css');
-
-		penthouse({
-			url: page1,
-			css: emptyRemoveCssFilePath
-		}, function(err, result) {
-			try {
-				result.trim().should.equal('');
-				done();
-			} catch (ex) {
-				done(ex);
-			}
-
-		});
-	});
-
-	it('should remove @fontface rule, because it is not used', function(done) {
-		var fontFaceRemoveCssFilePath = path.join(__dirname, 'static-server', 'fontface--remove.css'),
-			fontFaceRemoveCss = read(fontFaceRemoveCssFilePath).toString(),
-			ffRemover = require('../lib/phantomjs/unused-fontface-remover.js');
-
-		var result = ffRemover(fontFaceRemoveCss);
-
-		try {
-			var resultAst = css.parse(result);
-			var orgAst = css.parse(fontFaceRemoveCss);
-			resultAst.stylesheet.rules.should.have.length.lessThan(orgAst.stylesheet.rules.length);
-			done();
-		} catch (ex) {
-			done(ex);
-		}
-
-	});
-
-	it('should preformat css (rm comments etc)', function(done) {
-		var cssPreformatCssFilePath = path.join(__dirname, 'static-server', 'preformat-css--remove.css'),
-			cssPreformatCss = read(cssPreformatCssFilePath).toString(),
-			cssPreformatter = require('../lib/phantomjs/css-preformatter.js');
-
-		var result = cssPreformatter(cssPreformatCss);
-
-		try {
-			var resultAst = css.parse(result);
-			var orgAst = css.parse(cssPreformatCss);
-			//with comments stripped out, fewer 'rules' (comments included) in AST
-			resultAst.stylesheet.rules.should.have.length.lessThan(orgAst.stylesheet.rules.length);
-			//but except for comments, (also inside declarations), everything should be the same
-			var orgAstRulesExceptComments = orgAst.stylesheet.rules.filter(function(rule){
-				if(typeof rule.declarations !== "undefined") {
-					rule.declarations = rule.declarations.filter(function(declaration){
-						return declaration.type !== "comment"
-					})
-				}
-				return rule.type !== "comment";
-			})
-			orgAstRulesExceptComments.should.eql(resultAst.stylesheet.rules);
-
-			done();
-		} catch (ex) {
-			done(ex);
-		}
-
-	});
+    });
 
 });
 
 function startServer(done) {
-	var portfinder = require('portfinder');
+    var portfinder = require('portfinder');
 
-	portfinder.getPort(function(err, port) {
-		//
-		// `port` is guaranteed to be a free port
-		// in this scope.
+    portfinder.getPort(function (err, port) {
+        //
+        // `port` is guaranteed to be a free port
+        // in this scope.
 
-		var app = require('./static-server/app.js');
-		var server = app.listen(port);
+        var app = require('./static-server/app.js');
+        var server = app.listen(port);
 
-		done(server, port);
-	});
+        done(server, port);
+    });
 }

--- a/test/full-tests.js
+++ b/test/full-tests.js
@@ -281,36 +281,6 @@ describe('penthouse functionality tests', function () {
 
     });
 
-    it('should preformat css (rm comments etc)', function (done) {
-        var cssPreformatCssFilePath = path.join(__dirname, 'static-server', 'preformat-css--remove.css'),
-            cssPreformatCss = read(cssPreformatCssFilePath).toString(),
-            cssPreformatter = require('../lib/phantomjs/css-preformatter.js');
-
-        var result = cssPreformatter(cssPreformatCss);
-
-        try {
-            var resultAst = css.parse(result);
-            var orgAst = css.parse(cssPreformatCss);
-            //with comments stripped out, fewer 'rules' (comments included) in AST
-            resultAst.stylesheet.rules.should.have.length.lessThan(orgAst.stylesheet.rules.length);
-            //but except for comments, (also inside declarations), everything should be the same
-            var orgAstRulesExceptComments = orgAst.stylesheet.rules.filter(function (rule) {
-                if (typeof rule.declarations !== "undefined") {
-                    rule.declarations = rule.declarations.filter(function (declaration) {
-                        return declaration.type !== "comment"
-                    })
-                }
-                return rule.type !== "comment";
-            })
-            orgAstRulesExceptComments.should.eql(resultAst.stylesheet.rules);
-
-            done();
-        } catch (ex) {
-            done(ex);
-        }
-
-    });
-
 });
 
 function startServer(done) {

--- a/test/full-tests.js
+++ b/test/full-tests.js
@@ -281,6 +281,16 @@ describe('penthouse functionality tests', function () {
 
     });
 
+
+    it('should surface parsing errors to the end user', function (done) {
+        penthouse({
+            css: 'some.css'
+        }, function (err) {
+            if(err) done();
+            else { done(new Error('Did not get error'));}
+        });
+    });
+
 });
 
 function startServer(done) {

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -3,6 +3,7 @@ chai = require('chai'),
 expect = chai.expect;
 
 describe('options parsing ', function() {
+
     it('should handle argument strings without options', function() {
         var options = parse(['http://hw.no', 'main.css' ]);
 
@@ -45,5 +46,13 @@ describe('options parsing ', function() {
         expect(function() {
             parse(['--width', 'main.css' , 'http://hw.no']);
         }).to.throw(/Parsing error/);
+    });
+
+    it('should accept local file paths', function() {
+       expect( parse(['index.html', 'main.css'])
+       ).to.eql({
+            url : 'index.html',
+            css : 'main.css'
+        });
     });
 });


### PR DESCRIPTION
The options-parser was erroring on relative html paths, but the error it throws was not passed on by `core.js`, unless in `debug` mode. Instead the feedback was just the usage string, which was very confusing. In current master such relative html paths were just let through and worked fine. (I was never aware of this until now though).

To conclude: If the options parser is going to stop execution on errors that can't be easily understood via the usage string produced by `core.js`, then the logic needs to be changed so that core displays those errors. For now, as the invalid url guard disappears, no change in core is needed.