### PR TITLE
add version argument to CLI

### DIFF
--- a/bin/penthouse
+++ b/bin/penthouse
@@ -6,9 +6,15 @@
  */
 
 var penthouse = require('../lib/index.js'),
+    version = require('../package.json').version,
     parser = require('../lib/options-parser.js'),
     args = process.argv.slice(2),
     options;
+
+if(args.length === 1 && args[0] === '-v' || args[0] === '--version'){
+  console.log(version);
+  process.exit(0);
+}
 
 try { options = parser.parse(args); }
 catch(ex) {


### PR DESCRIPTION
Want to be able to handle `penthouse -v`, not sure this is the right way. cc @fatso83 .