### PR TITLE
Handle html string

### DIFF
--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -107,6 +107,228 @@ page.onCallback = function(css) {
   }
 };
 
+var evalutePageCss = function(options) {
+	debug('Starting sandboxed evaluation of CSS\n', options.css);
+	// sandboxed environments - no outside references
+	// arguments and return value must be primitives
+	// @see http://phantomjs.org/api/webpage/method/evaluate.html
+	page.evaluate(function sandboxed(css) {
+		var h = window.innerHeight,
+			renderWaitTime = 100, //ms TODO: user specifiable through options object
+			finished = false,
+			currIndex = 0,
+			forceRemoveNestedRule = false;
+
+		//split CSS so we can value the (selector) rules separately.
+		//but first, handle stylesheet initial non nested @-rules.
+		//they don't come with any associated rules, and should all be kept,
+		//so just keep them in critical css, but don't include them in split
+		var splitCSS = css.replace(/@(import|charset|namespace)[^;]*;/g, '');
+		var split = splitCSS.split(/[{}]/g);
+
+		var getNewValidCssSelector = function(i) {
+			var newSel = split[i];
+			/* HANDLE Nested @-rules */
+
+			/*Case 1: @-rule with CSS properties inside [REMAIN]
+				Can't remove @font-face rules here, don't know if used or not.
+				Another check at end for this purpose.
+			*/
+			if (/@(font-face)/gi.test(newSel)) {
+				//skip over this rule
+				currIndex = css.indexOf('}', currIndex) + 1;
+				return getNewValidCssSelector(i + 2);
+			}
+			/*Case 2: @-rule with CSS properties inside [REMOVE]
+				@page
+				This case doesn't need any special handling,
+				as this "selector" won't match anything on the page,
+				and will therefor be removed, together with it's css props
+			*/
+
+			/*Case 4: @-rule with full CSS (rules) inside [REMOVE]
+				@media print|speech|aural, @keyframes
+				Delete this rule and all its contents - doesn't belong in critical path CSS
+			*/
+			else if (/@(media (print|speech|aural)|(([a-z\-])*keyframes))/gi.test(newSel)) {
+				//force delete on child css rules
+				forceRemoveNestedRule = true;
+				return getNewValidCssSelector(i + 1);
+			}
+
+			/*Case 3: @-rule with full CSS (rules) inside [REMAIN]
+				This test is executed AFTER Case 4,
+				since we here match every remaining @media,
+				after @media print has been removed by Case 4 rule)
+				- just skip this particular line (i.e. keep), and continue checking the CSS inside as normal
+			*/
+			else if (/@(media|(-moz-)?document|supports)/gi.test(newSel)) {
+				return getNewValidCssSelector(i + 1);
+			}
+			/*
+				Resume normal execution after end of @-media rule with inside CSS rules (Case 3)
+				Also identify abrupt file end.
+			*/
+			else if (newSel.trim().length === 0) {
+				//abrupt file end
+				if (i + 1 >= split.length) {
+					//end of file
+					finished = true;
+					return false;
+				}
+				//end of @-rule (Case 3)
+				forceRemoveNestedRule = false;
+				return getNewValidCssSelector(i + 1);
+			}
+			return i;
+		};
+
+		var removeSelector = function(sel, selectorsKept) {
+			var selPos = css.indexOf(sel, currIndex);
+
+			//check what comes next: { or ,
+			var nextComma = css.indexOf(',', selPos);
+			var nextOpenBracket = css.indexOf('{', selPos);
+
+			if (selectorsKept > 0 || (nextComma > 0 && nextComma < nextOpenBracket)) {
+				//we already kept selectors from this rule, so rule will stay
+
+				//more selectors in selectorList, cut until (and including) next comma
+				if (nextComma > 0 && nextComma < nextOpenBracket) {
+					css = css.substring(0, selPos) + css.substring(nextComma + 1);
+				}
+				//final selector, cut until open bracket. Also remove previous comma, as the (new) last selector should not be followed by a comma.
+				else {
+					var prevComma = css.lastIndexOf(',', selPos);
+					css = css.substring(0, prevComma) + css.substring(nextOpenBracket);
+				}
+			} else {
+				//no part of selector (list) matched elements above fold on page - remove whole rule CSS rule
+				var endRuleBracket = css.indexOf('}', nextOpenBracket);
+
+				css = css.substring(0, selPos) + css.substring(endRuleBracket + 1);
+			}
+		};
+
+
+		var processCssRules = function() {
+			for (var i = 0; i < split.length; i = i + 2) {
+				//step over non DOM CSS selectors (@-rules)
+				i = getNewValidCssSelector(i);
+
+				//reach end of CSS
+				if (finished) {
+					//call final function to exit outside of phantom evaluate scope
+					window.callPhantom(css);
+				}
+
+				var fullSel = split[i];
+				//fullSel can contain combined selectors
+				//,f.e.  body, html {}
+				//split and check one such selector at the time.
+				var selSplit = fullSel.split(',');
+				//keep track - if we remove all selectors, we also want to remove the whole rule.
+				var selectorsKept = 0;
+				var aboveFold;
+
+				for (var j = 0; j < selSplit.length; j++) {
+					var sel = selSplit[j];
+
+					//some selectors can't be matched on page.
+					//In these cases we test a slightly modified selectors instead, temp.
+					var temp = sel;
+
+					if (sel.indexOf(':') > -1) {
+						//handle special case selectors, the ones that contain a semi colon (:)
+						//many of these selectors can't be matched to anything on page via JS,
+						//but that still might affect the above the fold styling
+
+						//these psuedo selectors depend on an element,
+						//so test element instead (would do the same for f.e. :hover, :focus, :active IF we wanted to keep them for critical path css, but we don't)
+						temp = temp.replace(/(:?:before|:?:after)*/g, '');
+
+						//if selector is purely psuedo (f.e. ::-moz-placeholder), just keep as is.
+						//we can't match it to anything on page, but it can impact above the fold styles
+						if (temp.replace(/:[:]?([a-zA-Z0-9\-\_])*/g, '').trim().length === 0) {
+							currIndex = css.indexOf(sel, currIndex) + sel.length;
+							selectorsKept++;
+							continue;
+						}
+
+						//handle browser specific psuedo selectors bound to elements,
+						//Example, button::-moz-focus-inner, input[type=number]::-webkit-inner-spin-button
+						//remove browser specific pseudo and test for element
+						temp = temp.replace(/:?:-[a-z-]*/g, '');
+					}
+
+					if (!forceRemoveNestedRule) {
+						//now we have a selector to test, first grab any matching elements
+						var el;
+						try {
+							el = document.querySelectorAll(temp);
+						} catch (e) {
+							//not a valid selector, remove it.
+							removeSelector(sel, 0);
+							continue;
+						}
+
+						//check if selector matched element(s) on page..
+						aboveFold = false;
+
+						for (var k = 0; k < el.length; k++) {
+							var testEl = el[k];
+							//temporarily force clear none in order to catch elements that clear previous content themselves and who w/o their styles could show up unstyled in above the fold content (if they rely on f.e. 'clear:both;' to clear some main content)
+							testEl.style.clear = 'none';
+
+							//check to see if any matched element is above the fold on current page
+							//(in current viewport size)
+							if (testEl.getBoundingClientRect().top < h) {
+								//then we will save this selector
+								aboveFold = true;
+								selectorsKept++;
+
+								//update currIndex so we only search from this point from here on.
+								currIndex = css.indexOf(sel, currIndex);
+
+								//set clear style back to what it was
+								testEl.style.clear = '';
+								//break, because matching 1 element is enough
+								break;
+							}
+							//set clear style back to what it was
+							testEl.style.clear = '';
+						}
+					} else {
+						aboveFold = false;
+					} //force removal of selector
+
+					//if selector didn't match any elements above fold - delete selector from CSS
+					if (aboveFold === false) {
+						//update currIndex so we only search from this point from here on.
+						currIndex = css.indexOf(sel, currIndex);
+						//remove seletor (also removes rule, if nnothing left)
+						removeSelector(sel, selectorsKept);
+					}
+				}
+				//if rule stayed, move our cursor forward for matching new selectors
+				if (selectorsKept > 0) {
+					currIndex = css.indexOf('}', currIndex) + 1;
+				}
+			}
+
+			//we're done - call final function to exit outside of phantom evaluate scope
+			window.callPhantom(css);
+		};
+
+		//give some time (renderWaitTime) for sites like facebook that build their page dynamically,
+		//otherwise we can miss some selectors (and therefor rules)
+		//--tradeoff here: if site is too slow with dynamic content,
+		//	it doesn't deserve to be in critical path.
+		setTimeout(processCssRules, renderWaitTime);
+
+	}, options.css);
+};
+
 /*
  * Tests each selector in css file at specified resolution,
  * to see if any such elements appears above the fold on the page
@@ -125,233 +347,23 @@ function getCriticalPathCss(options) {
 		height: options.height
 	};
 
-	page.open(options.url, function(status) {
-		if (status !== 'success') {
-			errorlog('Error opening url \'' + page.reason_url + '\': ' + page.reason);
-			phantom.exit(1);
-		} else {
+	if(options.url.indexOf('<html') >= 0){
+		debug('received html string; setting content...');
+		page.content = options.url;
 
-			debug('Starting sandboxed evaluation of CSS\n', options.css);
-			// sandboxed environments - no outside references
-			// arguments and return value must be primitives
-			// @see http://phantomjs.org/api/webpage/method/evaluate.html
-			page.evaluate(function sandboxed(css) {
-				var h = window.innerHeight,
-					renderWaitTime = 100, //ms TODO: user specifiable through options object
-					finished = false,
-					currIndex = 0,
-					forceRemoveNestedRule = false;
+		evalutePageCss(options);
 
-				//split CSS so we can value the (selector) rules separately.
-				//but first, handle stylesheet initial non nested @-rules.
-				//they don't come with any associated rules, and should all be kept,
-				//so just keep them in critical css, but don't include them in split
-				var splitCSS = css.replace(/@(import|charset|namespace)[^;]*;/g, '');
-				var split = splitCSS.split(/[{}]/g);
+	} else {
 
-				var getNewValidCssSelector = function(i) {
-					var newSel = split[i];
-					/* HANDLE Nested @-rules */
-
-					/*Case 1: @-rule with CSS properties inside [REMAIN]
-						Can't remove @font-face rules here, don't know if used or not.
-						Another check at end for this purpose.
-					*/
-					if (/@(font-face)/gi.test(newSel)) {
-						//skip over this rule
-						currIndex = css.indexOf('}', currIndex) + 1;
-						return getNewValidCssSelector(i + 2);
-					}
-					/*Case 2: @-rule with CSS properties inside [REMOVE]
-						@page
-						This case doesn't need any special handling,
-						as this "selector" won't match anything on the page,
-						and will therefor be removed, together with it's css props
-					*/
-
-					/*Case 4: @-rule with full CSS (rules) inside [REMOVE]
-						@media print|speech|aural, @keyframes
-						Delete this rule and all its contents - doesn't belong in critical path CSS
-					*/
-					else if (/@(media (print|speech|aural)|(([a-z\-])*keyframes))/gi.test(newSel)) {
-						//force delete on child css rules
-						forceRemoveNestedRule = true;
-						return getNewValidCssSelector(i + 1);
-					}
-
-					/*Case 3: @-rule with full CSS (rules) inside [REMAIN]
-						This test is executed AFTER Case 4,
-						since we here match every remaining @media,
-						after @media print has been removed by Case 4 rule)
-						- just skip this particular line (i.e. keep), and continue checking the CSS inside as normal
-					*/
-					else if (/@(media|(-moz-)?document|supports)/gi.test(newSel)) {
-						return getNewValidCssSelector(i + 1);
-					}
-					/*
-						Resume normal execution after end of @-media rule with inside CSS rules (Case 3)
-						Also identify abrupt file end.
-					*/
-					else if (newSel.trim().length === 0) {
-						//abrupt file end
-						if (i + 1 >= split.length) {
-							//end of file
-							finished = true;
-							return false;
-						}
-						//end of @-rule (Case 3)
-						forceRemoveNestedRule = false;
-						return getNewValidCssSelector(i + 1);
-					}
-					return i;
-				};
-
-				var removeSelector = function(sel, selectorsKept) {
-					var selPos = css.indexOf(sel, currIndex);
-
-					//check what comes next: { or ,
-					var nextComma = css.indexOf(',', selPos);
-					var nextOpenBracket = css.indexOf('{', selPos);
-
-					if (selectorsKept > 0 || (nextComma > 0 && nextComma < nextOpenBracket)) {
-						//we already kept selectors from this rule, so rule will stay
-
-						//more selectors in selectorList, cut until (and including) next comma
-						if (nextComma > 0 && nextComma < nextOpenBracket) {
-							css = css.substring(0, selPos) + css.substring(nextComma + 1);
-						}
-						//final selector, cut until open bracket. Also remove previous comma, as the (new) last selector should not be followed by a comma.
-						else {
-							var prevComma = css.lastIndexOf(',', selPos);
-							css = css.substring(0, prevComma) + css.substring(nextOpenBracket);
-						}
-					} else {
-						//no part of selector (list) matched elements above fold on page - remove whole rule CSS rule
-						var endRuleBracket = css.indexOf('}', nextOpenBracket);
-
-						css = css.substring(0, selPos) + css.substring(endRuleBracket + 1);
-					}
-				};
-
-
-				var processCssRules = function() {
-					for (var i = 0; i < split.length; i = i + 2) {
-						//step over non DOM CSS selectors (@-rules)
-						i = getNewValidCssSelector(i);
-
-						//reach end of CSS
-						if (finished) {
-							//call final function to exit outside of phantom evaluate scope
-							window.callPhantom(css);
-						}
-
-						var fullSel = split[i];
-						//fullSel can contain combined selectors
-						//,f.e.  body, html {}
-						//split and check one such selector at the time.
-						var selSplit = fullSel.split(',');
-						//keep track - if we remove all selectors, we also want to remove the whole rule.
-						var selectorsKept = 0;
-						var aboveFold;
-
-						for (var j = 0; j < selSplit.length; j++) {
-							var sel = selSplit[j];
-
-							//some selectors can't be matched on page.
-							//In these cases we test a slightly modified selectors instead, temp.
-							var temp = sel;
-
-							if (sel.indexOf(':') > -1) {
-								//handle special case selectors, the ones that contain a semi colon (:)
-								//many of these selectors can't be matched to anything on page via JS,
-								//but that still might affect the above the fold styling
-
-								//these psuedo selectors depend on an element,
-								//so test element instead (would do the same for f.e. :hover, :focus, :active IF we wanted to keep them for critical path css, but we don't)
-								temp = temp.replace(/(:?:before|:?:after)*/g, '');
-
-								//if selector is purely psuedo (f.e. ::-moz-placeholder), just keep as is.
-								//we can't match it to anything on page, but it can impact above the fold styles
-								if (temp.replace(/:[:]?([a-zA-Z0-9\-\_])*/g, '').trim().length === 0) {
-									currIndex = css.indexOf(sel, currIndex) + sel.length;
-									selectorsKept++;
-									continue;
-								}
-
-								//handle browser specific psuedo selectors bound to elements,
-								//Example, button::-moz-focus-inner, input[type=number]::-webkit-inner-spin-button
-								//remove browser specific pseudo and test for element
-								temp = temp.replace(/:?:-[a-z-]*/g, '');
-							}
-
-							if (!forceRemoveNestedRule) {
-								//now we have a selector to test, first grab any matching elements
-								var el;
-								try {
-									el = document.querySelectorAll(temp);
-								} catch (e) {
-									//not a valid selector, remove it.
-									removeSelector(sel, 0);
-									continue;
-								}
-
-								//check if selector matched element(s) on page..
-								aboveFold = false;
-
-								for (var k = 0; k < el.length; k++) {
-									var testEl = el[k];
-									//temporarily force clear none in order to catch elements that clear previous content themselves and who w/o their styles could show up unstyled in above the fold content (if they rely on f.e. 'clear:both;' to clear some main content)
-									testEl.style.clear = 'none';
-
-									//check to see if any matched element is above the fold on current page
-									//(in current viewport size)
-									if (testEl.getBoundingClientRect().top < h) {
-										//then we will save this selector
-										aboveFold = true;
-										selectorsKept++;
-
-										//update currIndex so we only search from this point from here on.
-										currIndex = css.indexOf(sel, currIndex);
-
-										//set clear style back to what it was
-										testEl.style.clear = '';
-										//break, because matching 1 element is enough
-										break;
-									}
-									//set clear style back to what it was
-									testEl.style.clear = '';
-								}
-							} else {
-								aboveFold = false;
-							} //force removal of selector
-
-							//if selector didn't match any elements above fold - delete selector from CSS
-							if (aboveFold === false) {
-								//update currIndex so we only search from this point from here on.
-								currIndex = css.indexOf(sel, currIndex);
-								//remove seletor (also removes rule, if nnothing left)
-								removeSelector(sel, selectorsKept);
-							}
-						}
-						//if rule stayed, move our cursor forward for matching new selectors
-						if (selectorsKept > 0) {
-							currIndex = css.indexOf('}', currIndex) + 1;
-						}
-					}
-
-					//we're done - call final function to exit outside of phantom evaluate scope
-					window.callPhantom(css);
-				};
-
-				//give some time (renderWaitTime) for sites like facebook that build their page dynamically,
-				//otherwise we can miss some selectors (and therefor rules)
-				//--tradeoff here: if site is too slow with dynamic content,
-				//	it doesn't deserve to be in critical path.
-				setTimeout(processCssRules, renderWaitTime);
-
-			}, options.css);
-		}
-	});
+		page.open(options.url, function(status) {
+			if (status !== 'success') {
+				errorlog('Error opening url \'' + page.reason_url + '\': ' + page.reason);
+				phantom.exit(1);
+			} else {
+				evalutePageCss(options);
+			}
+		});
+	}
 }
 
 var parser, parse, usage, options;

--- a/test/full-tests.js
+++ b/test/full-tests.js
@@ -35,14 +35,14 @@ describe('penthouse functionality tests', function () {
 
     it('should match exactly the css in the yeoman test', function (done) {
         var yeomanFullCssFilePath = path.join(__dirname, 'static-server', 'yeoman-full.css'),
-            yeomanExpectedCssFilePath = path.join(__dirname, 'static-server', 'yeoman-small-expected.css'),
+            yeomanExpectedCssFilePath = path.join(__dirname, 'static-server', 'yeoman-medium--expected.css'),
             yeomanExpectedCss = read(yeomanExpectedCssFilePath).toString();
 
         penthouse({
             url: path.join(__dirname, 'static-server', 'yeoman.html'),
             css: yeomanFullCssFilePath,
-            width: 320,
-            height: 70
+            width: 800,
+            height: 450
         }, function (err, result) {
             if (err) {
                 done(err);

--- a/test/full-tests.js
+++ b/test/full-tests.js
@@ -273,4 +273,28 @@ describe('penthouse functionality tests', function () {
             else { done(new Error('Did not get error'));}
         });
     });
+
+
+    it('should handle html passed in as string', function (done) {
+      var yeomanFullCssFilePath = path.join(__dirname, 'static-server', 'yeoman-full.css'),
+      // TODO: replace with full-expected
+          yeomanExpectedCssFilePath = path.join(__dirname, 'static-server', 'yeoman-small-expected.css'),
+          yeomanExpectedCss = read(yeomanExpectedCssFilePath).toString(),
+          yeomanHtmlString = read(path.join(__dirname, 'static-server', 'yeoman.html')).toString();
+
+      penthouse({
+        url: yeomanHtmlString,
+        css: yeomanFullCssFilePath
+      }, function (err, result) {
+        if(err) { done(err); }
+        try {
+          var resultAst = css.parse(result);
+          var expectedAst = css.parse(yeomanExpectedCss);
+          resultAst.should.eql(expectedAst);
+          done();
+        } catch (ex) {
+          done(ex);
+        }
+      });
+  });
 });

--- a/test/static-server/yeoman-medium--expected.css
+++ b/test/static-server/yeoman-medium--expected.css
@@ -3,8 +3,8 @@ body {
     padding-bottom: 20px;
 }
 
-::selection{color:#fff}ul{list-style:none}
 
+::selection{color:#fff}ul{list-style:none}
 
 .header{
     padding-left: 15px;
@@ -25,6 +25,17 @@ body {
 }
 
 
+.jumbotron {
+    text-align: center;
+    border-bottom: 1px solid #e5e5e5;
+}
+
+.jumbotron .btn {
+    font-size: 21px;
+    padding: 14px 24px;
+}
+
+
 @media screen and (min-width: 768px) {
     .container {
         max-width: 730px;
@@ -40,8 +51,12 @@ body {
     .header {
         margin-bottom: 30px;
     }
-}
 
+
+    .jumbotron {
+        border-bottom: 0;
+    }
+}
 
 
 
@@ -55,6 +70,10 @@ body {
 }
 a {
   background: transparent;
+}
+h1 {
+  margin: .67em 0;
+  font-size: 2em;
 }
 * {
   -webkit-box-sizing: border-box;
@@ -83,18 +102,37 @@ a {
   color: #428bca;
   text-decoration: none;
 }
+h1,
 h3{
   font-family: inherit;
   font-weight: 500;
   line-height: 1.1;
   color: inherit;
 }
+h1,
 h3{
   margin-top: 20px;
   margin-bottom: 10px;
 }
+h1{
+  font-size: 36px;
+}
 h3{
   font-size: 24px;
+}
+p {
+  margin: 0 0 10px;
+}
+.lead {
+  margin-bottom: 20px;
+  font-size: 16px;
+  font-weight: 200;
+  line-height: 1.4;
+}
+@media (min-width: 768px) {
+  .lead {
+    font-size: 21px;
+  }
 }
 .text-muted {
   color: #999;
@@ -124,6 +162,36 @@ ul{
     width: 1170px;
   }
 }
+.btn {
+  display: inline-block;
+  padding: 6px 12px;
+  margin-bottom: 0;
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 1.42857143;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+.btn-success {
+  color: #fff;
+  background-color: #5cb85c;
+  border-color: #4cae4c;
+}
+.btn-lg{
+  padding: 10px 16px;
+  font-size: 18px;
+  line-height: 1.33;
+  border-radius: 6px;
+}
 
 .nav {
   padding-left: 0;
@@ -151,6 +219,36 @@ ul{
 .nav-pills > li.active > a{
   color: #fff;
   background-color: #428bca;
+}
+.jumbotron {
+  padding: 30px;
+  margin-bottom: 30px;
+  color: inherit;
+  background-color: #eee;
+}
+.jumbotron h1{
+  color: inherit;
+}
+.jumbotron p {
+  margin-bottom: 15px;
+  font-size: 21px;
+  font-weight: 200;
+}
+.container .jumbotron {
+  border-radius: 6px;
+}
+@media screen and (min-width: 768px) {
+  .jumbotron {
+    padding-top: 48px;
+    padding-bottom: 48px;
+  }
+  .container .jumbotron {
+    padding-right: 60px;
+    padding-left: 60px;
+  }
+  .jumbotron h1{
+    font-size: 63px;
+  }
 }
 .container:before,
 .container:after,


### PR DESCRIPTION
Add support to pass in a `html` string instead of `url`. Should perhaps go as separate option for node module. Fine to not support at all for CLI.

Cannot figure out why `page.content = <html string>` produces ever so slightly different result than `page.open(<html url>)` in `PhantomJS`, failing the test I added... Html is the same, viewport dimensions are the same, but critical css comes back with some extra or missing rules, indicating that something is not taking up the same space on the page (or the the viewport dimensions are incorrect)...