### PR TITLE
Disable web-security

### DIFF
--- a/lib/phantomjs/config.json
+++ b/lib/phantomjs/config.json
@@ -1,4 +1,5 @@
 {
 	"ignoreSslErrors": true,
-	"sslProtocol": "tlsv1"
+	"sslProtocol": "tlsv1",
+	"webSecurityEnabled": false
 }


### PR DESCRIPTION
To suppress phantom exit error, as describe in https://github.com/pocketjoso/penthouse/issues/58

Pro: simple and straight-forward.

Con: potential security issue if you build in production environment.