### PR TITLE
Wrap phantom exit in setTimeout

### DIFF
--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -21,6 +21,16 @@ var debug = function() {
 	if (DEBUG) errorlog('DEBUG: ' + combineArgsString(arguments));
 };
 
+// discard stdout from phantom exit;
+var phantomExit = function(code) {
+	if (page) {
+		page.close();
+	}
+	setTimeout(function() {
+		phantom.exit(code);
+	}, 0);
+};
+
 //don't confuse analytics more than necessary when visiting websites
 page.settings.userAgent = 'Penthouse Critical Path CSS Generator';
 
@@ -51,7 +61,7 @@ var main = function(options) {
 		options.css = cssPreformat(f.read());
 	} catch (e) {
 		errorlog(e);
-		phantom.exit(1);
+		phantomExit(1);
 	}
 
   // start the critical path CSS generation
@@ -90,20 +100,20 @@ page.onCallback = function(css) {
 
       // return the critical css!
       stdout.write(finalCss);
-      phantom.exit(0);
+      phantomExit(0);
     } else {
       // No css. This is not an error on our part
       // but still safer to warn the end user, in case they made a mistake
       errorlog('Note: Generated critical css was empty for URL: ' + options.url);
       // for consisteny, still generate output (will be empty)
       stdout.write(css);
-      phantom.exit(0);
+      phantomExit(0);
     }
 
   } catch (ex) {
     debug('phantom.onCallback -> error', ex);
     errorlog('error: ' + ex);
-    phantom.exit(1);
+    phantomExit(1);
   }
 };
 
@@ -128,7 +138,7 @@ function getCriticalPathCss(options) {
 	page.open(options.url, function(status) {
 		if (status !== 'success') {
 			errorlog('Error opening url \'' + page.reason_url + '\': ' + page.reason);
-			phantom.exit(1);
+			phantomExit(1);
 		} else {
 
 			debug('Starting sandboxed evaluation of CSS\n', options.css);
@@ -378,7 +388,7 @@ try {
         errorlog('\nUsage: phantomjs penthouse.js ' + usage);
     }
 
-	phantom.exit(1);
+	phantomExit(1);
 }
 
 // set defaults


### PR DESCRIPTION
This PR implements the solution 2 in #58 

Pro: will work with phantomjs core v1.9.8, so it works with latest nodejs wrapper (currently at v1.9.17).

Con: hopefully no one will need to debug phantom exit output.

It works consistently on my repo, let's see if I broke any travis tests...