### PR TITLE
Force include 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ penthouse({
     // OPTIONAL params
     width : 1300,   // viewport width
     height : 900,   // viewport height
+    forceInclude : [
+      '.keepMeEvenIfNotSeenInDom',
+      /^\.regexWorksToo/
+    ],
     timeout: 30000 // ms; abort critical css generation after this timeout
 }, function(err, criticalCss) {
     if (err) { // handle error }

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,13 +26,23 @@ var m = module.exports = function (options, callback) {
         debuggingHelp = '',
         cp
 
-    // set the options, falling back to defaults
-    var scriptArgs = [
-      options.url || '',
-      options.css || '',
-      options.width || DEFAULT_VIEWPORT_WIDTH,
-      options.height || DEFAULT_VIEWPORT_HEIGHT
-    ]
+  // need to annotate forceInclude values to allow RegExp to pass through JSON serialization
+  // also need to give them a toJSON method
+  RegExp.prototype.toJSON = RegExp.prototype.toString;
+  var forceInclude = (options.forceInclude || []).map(function (forceIncludeValue) {
+    if (typeof forceIncludeValue === 'object' && forceIncludeValue.constructor.name === 'RegExp') {
+      return { type: 'RegExp', value: forceIncludeValue.source };
+    }
+    return { value: forceIncludeValue };
+  })
+  // set the options, falling back to defaults
+  var scriptArgs = [
+    options.url || '',
+    options.css || '',
+    options.width || DEFAULT_VIEWPORT_WIDTH,
+    options.height || DEFAULT_VIEWPORT_HEIGHT,
+    JSON.stringify(forceInclude) // stringify to maintain array
+  ]
 
   cp = spawn(phantomJsBinPath, [configString, script].concat(scriptArgs));
 

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -128,7 +128,7 @@ function getCriticalPathCss(options) {
 			// sandboxed environments - no outside references
 			// arguments and return value must be primitives
 			// @see http://phantomjs.org/api/webpage/method/evaluate.html
-			page.evaluate(function sandboxed(ast) {
+			page.evaluate(function sandboxed(ast, forceInclude) {
 				var h = window.innerHeight,
 					renderWaitTime = 100; //ms TODO: user specifiable through options object
 
@@ -143,9 +143,20 @@ function getCriticalPathCss(options) {
 					return aboveFold;
 				};
 
+				var matchesForceInclude = function (selector) {
+					return forceInclude.some(function (includeSelector) {
+						if (includeSelector.type === 'RegExp') {
+							var pattern = new RegExp(includeSelector.value)
+							console.log(pattern, selector, pattern.test(selector))
+							return pattern.test(selector)
+						}
+						return includeSelector.value === selector
+					})
+				}
+
 				var isSelectorCritical = function (selector) {
-					if (selector.trim() === '*') {
-						return true;
+					if (matchesForceInclude(selector.trim())) {
+						return true
 					}
 
 					//some selectors can't be matched on page.
@@ -246,7 +257,7 @@ function getCriticalPathCss(options) {
 				//	it doesn't deserve to be in critical path.
 				setTimeout(processCssRules, renderWaitTime);
 
-			}, options.ast);
+			}, options.ast, options.forceInclude);
 		}
 	});
 }
@@ -257,11 +268,14 @@ if (args.length < 4) {
 	errorlog('Caught error parsing arguments: ' + ex.message);
 	phantomExit(1);
 }
+
 var options = {
 	url: args[1],
 	css: args[2],
 	width: args[3],
-	height: args[4]
+	height: args[4],
+	// always forceInclude '*' selector
+	forceInclude: [{ value: '*' }].concat(JSON.parse(args[5]) || [])
 }
 
 main(options);

--- a/test/core-tests.js
+++ b/test/core-tests.js
@@ -229,9 +229,32 @@ describe('penthouse core tests', function () {
             } catch (ex) {
                 done(ex);
             }
-
         });
     });
+
+    it('should force include specified selectors', function (done) {
+      var forceIncludeCssFilePath = path.join(__dirname, 'static-server', 'forceInclude.css'),
+          forceIncludeCss = read(forceIncludeCssFilePath).toString()
+      penthouse({
+        url: path.join(__dirname, 'static-server', 'page1.html'),
+        css: forceIncludeCssFilePath,
+        forceInclude: [
+          '.myLoggedInSelectorRemainsEvenThoughNotFoundOnPage',
+          '#box1:hover',
+          /^\.component/
+        ]
+      }, function (err, result) {
+        try {
+          var resultAst = normalisedCssAst(result);
+          var expectedAst = normalisedCssAst(forceIncludeCss);
+          resultAst.should.eql(expectedAst);
+          done();
+        } catch (ex) {
+          done(ex);
+        }
+      });
+    });
+
 
     /* non core (non breaking) functionality tests */
     it('should remove empty rules', function (done) {

--- a/test/static-server/forceInclude.css
+++ b/test/static-server/forceInclude.css
@@ -1,0 +1,17 @@
+.myLoggedInSelectorRemainsEvenThoughNotFoundOnPage {
+  color: red;
+}
+/* #box1 appears on page, but normally :hover styles would be removed */
+#box1:hover {
+  color: red;
+}
+/* used to demonstrate regex forceInclude of full component */
+.component {
+  color: red;
+}
+  .component__part {
+    color: blue;
+  }
+  .component__part--modifier {
+    color: green;
+  }


### PR DESCRIPTION
For #61.

Node module now takes an array of selectors that will not be removed even if they don't appear in the critical viewport:
``` 
penthouse({
  ...
  forceInclude: [ '.myLoggedInSelector', '.andFriends', /^\.andRegexToo.*/ ] 
});
```