### PR TITLE
lower phantomjs security settings

### DIFF
--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -31,8 +31,12 @@ var phantomExit = function(code) {
 	}, 0);
 };
 
-//don't confuse analytics more than necessary when visiting websites
+// don't confuse analytics more than necessary when visiting websites
 page.settings.userAgent = 'Penthouse Critical Path CSS Generator';
+
+// we don't really care about web security for generating the css
+page.settings.webSecurityEnabled = false;
+page.settings.localToRemoteUrlAccessEnabled = true;
 
 /* prevent page JS errors from being output to final CSS */
 page.onError = function(msg, trace) {


### PR DESCRIPTION
Ignoring more errors thrown by `phantomjs`, for #58 .

Untested.