### PR TITLE
silence known phantomjs stdout security errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,13 @@ var phantomJsBinPath = phantomjs.path;
 var configString = ('--config=' + path.join(__dirname, 'phantomjs', 'config.json'));
 var script = path.join(__dirname, 'phantomjs', 'core.js');
 
+var removePhantomJSSecurityErrors = function (stdOut){
+  stdOut = stdOut.replace("Unsafe JavaScript attempt to access frame with URL about:blank from frame with URL ", "");
+  stdOut = stdOut.replace(/file:\/\/.*core.js\./, "");
+  stdOut = stdOut.replace(" Domains, protocols and ports must match.", "");
+  return stdOut;
+};
+
 var m = module.exports = function (options, callback) {
     var scriptArgs = [],
         stdOut = '',
@@ -54,6 +61,8 @@ var m = module.exports = function (options, callback) {
                 console.log('stdout: ' + stdOut);
                 console.log('stderr: ' + stdErr);
             }
+            stdOut += 'Unsafe JavaScript attempt to access frame with URL about:blank from frame with URL file:///Users/local/git/mai/node_modules/penthouse/lib/phantomjs/core.js. Domains, protocols and ports must match.';
+            stdOut = removePhantomJSSecurityErrors(stdOut);
             callback(null, stdOut);
         } else {
             debuggingHelp += 'PhantomJS process exited with code ' + code;


### PR DESCRIPTION
Fix for known phantomjs security errors going to `stdout`, resolves #58 and related issues.

Not the best way to solve this, but again these problems should disappear in `phantomjs 2`. Solution pretty much copied from [criticalCSS](https://github.com/filamentgroup/criticalCSS/blob/master/critical.js#L61-L64).