### PR TITLE
Fix non ascii crashes

### DIFF
--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -146,6 +146,10 @@ function getCriticalPathCss(options) {
 			// arguments and return value must be primitives
 			// @see http://phantomjs.org/api/webpage/method/evaluate.html
 			page.evaluate(function sandboxed(css) {
+				// need to encode/decode css for phantomjs' bridge serialization,
+				// otherwise certain non ASCII chars causes it to hang, f.e. Unicode Character 'LINE SEPARATOR' (U+2028)
+				css = decodeURIComponent(css);
+
 				var h = window.innerHeight,
 					renderWaitTime = 100, //ms TODO: user specifiable through options object
 					finished = false,
@@ -359,7 +363,7 @@ function getCriticalPathCss(options) {
 				//	it doesn't deserve to be in critical path.
 				setTimeout(processCssRules, renderWaitTime);
 
-			}, options.css);
+			}, encodeURIComponent(options.css));
 		}
 	});
 }

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -45,7 +45,7 @@ page.onResourceError = function(resourceError) {
 };
 
 var main = function(options) {
-  debug('main(): ', JSON.stringify(options));
+  debug('main()');
 //final cleanup
 //remove all empty rules, and remove leading/trailing whitespace
 	try {
@@ -128,7 +128,7 @@ page.onCallback = function(css) {
  * @param options.height the height of viewport
  ---------------------------------------------------------*/
 function getCriticalPathCss(options) {
-	debug('getCriticalPathCss():', JSON.stringify(options));
+	debug('getCriticalPathCss():');
 
 	page.viewportSize = {
 		width: options.width,
@@ -141,7 +141,7 @@ function getCriticalPathCss(options) {
 			phantomExit(1);
 		} else {
 
-			debug('Starting sandboxed evaluation of CSS\n', options.css);
+			debug('Starting sandboxed evaluation of CSS');
 			// sandboxed environments - no outside references
 			// arguments and return value must be primitives
 			// @see http://phantomjs.org/api/webpage/method/evaluate.html

--- a/test/basic-tests.js
+++ b/test/basic-tests.js
@@ -81,4 +81,19 @@ describe('basic tests of penthouse functionality', function () {
 
 		});
 	});
+
+	it('should not crash on special chars', function (done) {
+		penthouse({
+			url: page1,
+			css: path.join(__dirname, 'static-server', 'special-chars.css')
+		}, function (err, result) {
+			if(err) { done(err); }
+			try {
+				css.parse(result);
+				done();
+			} catch (ex) {
+				done(ex);
+			}
+		});
+	});
 });

--- a/test/static-server/special-chars.css
+++ b/test/static-server/special-chars.css
@@ -1,0 +1,9 @@
+html {
+	color: red;
+}
+.test  { /* there is a special Unicode Character 'LINE SEPARATOR' (U+2028) after t, before space.. breaks phantomJS */
+	color: red;
+}
+.test💩 {
+	color: red;
+}


### PR DESCRIPTION
The presence of certain non ASCII characters in the `css` passed to `Penthouse` cause `Phantomjs` to hang forever (on the serialization of params?) in `Page.evaluate`. This fixes that by escaping the css before calling Phantom.