### PR TITLE
Remove unmatched media queries

### DIFF
--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -2,8 +2,9 @@
 
 var cssAstFormatter = require('css'),
   embeddedbase64Remover = require('./embedded-base64-remover'),
-  ffRemover = require('./unused-fontface-remover.js'),
+  ffRemover = require('./unused-fontface-remover'),
   fs = require('fs'),
+  nonMatchingMediaQueryRemover = require('./non-matching-media-query-remover'),
   system = require('system'),
   stdout = system.stdout, // for using this as a file
   webpage = require('webpage'),
@@ -165,7 +166,7 @@ function normalizeCss (css) {
 // called inside a sandboxed environment inside phantomjs - no outside references
 // arguments and return value must be primitives
 // @see http://phantomjs.org/api/webpage/method/evaluate.html
-function pruneNonCriticalCss (ast, forceInclude, doneStatus) {
+function pruneNonCriticalCss (astRules, forceInclude, doneStatus) {
   var h = window.innerHeight,
     renderWaitTime = 100; // ms TODO: user specifiable through options object
 
@@ -267,8 +268,8 @@ function pruneNonCriticalCss (ast, forceInclude, doneStatus) {
     /*Case 3: @-rule with full CSS (rules) inside [REMAIN]
     */
     if (
-      // TODO: remove media queries larger than critical dimensions
-      rule.type === 'media' && rule.media !== 'print' ||
+      // non matching media queries are stripped out in non-matching-media-query-remover.js
+      rule.type === 'media' ||
       rule.type === 'document' ||
       rule.type === 'supports'
     ) {
@@ -281,7 +282,7 @@ function pruneNonCriticalCss (ast, forceInclude, doneStatus) {
   }
 
   var processCssRules = function () {
-    var criticalRules = ast.stylesheet.rules.filter(isCssRuleCritical)
+    var criticalRules = astRules.filter(isCssRuleCritical)
 
     // we're done - call final function to exit outside of phantom evaluate scope
     window.callPhantom({
@@ -312,13 +313,15 @@ function getCriticalPathCss (options) {
     width: options.width,
     height: options.height
   }
+  // first strip out non matching media queries
+  var astRules = nonMatchingMediaQueryRemover(options.ast.stylesheet.rules, options.width, options.height)
 
   page.open(options.url, function (status) {
     if (status !== 'success') {
       errorlog("Error opening url '" + page.reason_url + "': " + page.reason)
       phantomExit(1)
     } else {
-      page.evaluate(pruneNonCriticalCss, options.ast, options.forceInclude, GENERATION_DONE)
+      page.evaluate(pruneNonCriticalCss, astRules, options.forceInclude, GENERATION_DONE)
     }
   })
 }

--- a/lib/phantomjs/non-matching-media-query-remover.js
+++ b/lib/phantomjs/non-matching-media-query-remover.js
@@ -1,0 +1,35 @@
+var cssMediaQuery = require('css-mediaquery')
+// only filter out: print, min-width > width and min-height > height
+
+function _isMatchingMediaQuery (rule, matchConfig) {
+  if (rule.type !== 'media') {
+    // ignore (keep) all non media query rules
+    return true
+  }
+
+  var mediaAST = cssMediaQuery.parse(rule.media)
+  var keep = mediaAST.some(function (mq) {
+    if (mq.type === 'print') {
+      return false
+    }
+    return mq.expressions.some(function (expression, index) {
+      if (expression.modifier === 'min') {
+        return cssMediaQuery.match('(min-' + expression.feature + ':' + expression.value + ')', matchConfig)
+      } else {
+        return true
+      }
+    })
+  })
+  return keep
+}
+
+function nonMatchingMediaQueryRemover (rules, width, height) {
+  var matchConfig = { type: 'screen', width: width + 'px', height: height + 'px' }
+  return rules.filter(function (rule) {
+    return _isMatchingMediaQuery(rule, matchConfig)
+  })
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = nonMatchingMediaQueryRemover
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "css": "2.0.0",
+    "css-mediaquery": "^0.1.2",
     "phantomjs": "~1.9.7"
   },
   "devDependencies": {

--- a/test/core-tests.js
+++ b/test/core-tests.js
@@ -8,6 +8,7 @@ chai.should() // binds globally on Object
 
 import ffRemover from '../lib/phantomjs/unused-fontface-remover'
 import embeddedbase64Remover from '../lib/phantomjs/embedded-base64-remover'
+import nonMatchingMediaQueryRemover from '../lib/phantomjs/non-matching-media-query-remover'
 
 process.setMaxListeners(0)
 
@@ -277,5 +278,15 @@ describe('penthouse core tests', function () {
     } catch (ex) {
       done(ex)
     }
+  })
+
+  it('should remove non matching media queries', function (done) {
+    const originalCss = read(path.join(__dirname, 'static-server', 'non-matching-mq--remove.css'), 'utf8')
+    const defaultViewportRules = nonMatchingMediaQueryRemover(css.parse(originalCss).stylesheet.rules, 1300, 900)
+    defaultViewportRules.should.have.length(1)
+
+    const smallViewportRules = nonMatchingMediaQueryRemover(css.parse(originalCss).stylesheet.rules, 600, 600)
+    smallViewportRules.should.have.length(0)
+    done()
   })
 })

--- a/test/static-server/non-matching-mq--remove.css
+++ b/test/static-server/non-matching-mq--remove.css
@@ -1,0 +1,20 @@
+@media print {
+  body { color: red }
+}
+
+@media (min-width: 800px) { 
+  body { color: red }
+}
+@media (min-width: 1500px) {
+  body { color: red }
+}
+@media (min-height: 1000px) {
+  body { color: red }
+}
+
+@media screen and (min-width: 93.75em) {
+  body { color: red }
+}
+@media screen and (min-width: 93.75rem) {
+  body { color: red }
+}

--- a/test/static-server/yeoman-medium--expected.css
+++ b/test/static-server/yeoman-medium--expected.css
@@ -152,16 +152,6 @@ ul{
     width: 750px;
   }
 }
-@media (min-width: 992px) {
-  .container {
-    width: 970px;
-  }
-}
-@media (min-width: 1200px) {
-  .container {
-    width: 1170px;
-  }
-}
 .btn {
   display: inline-block;
   padding: 6px 12px;


### PR DESCRIPTION
`print` media queries were already removed, now `Penthouse` also removes and `min-width` / `min-height` media query that exceeds the defined viewport size (1300x900 by default).

Resolves #67.