### PR TITLE
abort js requests

### DIFF
--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -50,6 +50,13 @@ function prepareNewPage () {
     // do nothing
   }
 
+  page.onResourceRequested = function (requestData, request) {
+    if (/\.js(\?.*)?$/.test(requestData.url)) {
+      errorlog('aborting js request', requestData.url)
+      request.abort()
+    }
+  }
+
   page.onResourceError = function (resourceError) {
     page.reason = resourceError.errorString
     page.reason_url = resourceError.url


### PR DESCRIPTION
the first render happens before these requests resolve, so just wasteful to execute them.

If necessary can provide an option for this in the future, to override these request abortions, perhaps via regex or string matching.