### PR TITLE
Handle invalid media queries

### DIFF
--- a/lib/phantomjs/non-matching-media-query-remover.js
+++ b/lib/phantomjs/non-matching-media-query-remover.js
@@ -7,7 +7,12 @@ function _isMatchingMediaQuery (rule, matchConfig) {
     return true
   }
 
-  var mediaAST = cssMediaQuery.parse(rule.media)
+  try {
+    var mediaAST = cssMediaQuery.parse(rule.media)
+  } catch (e) {
+    // cant parse, most likely browser cant either
+    return false
+  }
   var keep = mediaAST.some(function (mq) {
     if (mq.type === 'print') {
       return false

--- a/test/basic-tests.js
+++ b/test/basic-tests.js
@@ -96,6 +96,21 @@ describe('basic tests of penthouse functionality', function () {
     })
   })
 
+  it('should not crash on invalid media query', function (done) {
+    penthouse({
+      url: page1,
+      css: path.join(__dirname, 'static-server', 'invalid-media.css')
+    }, function (err, result) {
+      if (err) { done(err) }
+      try {
+        css.parse(result)
+        done()
+      } catch (ex) {
+        done(ex)
+      }
+    })
+  })
+
   it('should crash with errors in strict mode on invalid css', function (done) {
     penthouse({
       url: page1,

--- a/test/static-server/invalid-media.css
+++ b/test/static-server/invalid-media.css
@@ -1,0 +1,5 @@
+@media(max-width:"" vc_responsive_max_w ""){
+	body {
+		color: red;
+	}
+}


### PR DESCRIPTION
Since #88 and the introduction of https://github.com/ericf/css-mediaquery in penthouse certain invalid media queries has caused penthouse to hang - this fixes that.