### PR TITLE
Remove unused CSS properties

### DIFF
--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -3,6 +3,7 @@
 var cssAstFormatter = require('css'),
   embeddedbase64Remover = require('./embedded-base64-remover'),
   ffRemover = require('./unused-fontface-remover'),
+  apartment = require('apartment'),
   fs = require('fs'),
   nonMatchingMediaQueryRemover = require('./non-matching-media-query-remover'),
   system = require('system'),
@@ -91,6 +92,12 @@ function returnCssFromAstRules (criticalRules) {
 
       // remove unused @fontface rules
       finalCss = ffRemover(finalCss)
+
+      // remove irrelevant css properties
+      finalCss = apartment(finalCss, {
+        properties: ['(.*)(animation|transition)(.*)', 'cursor', 'pointer-events'],
+        selectors: ['::(-moz-)?selection']
+      })
 
       if (finalCss.trim().length === 0) {
         errorlog('Note: Generated critical css was empty for URL: ' + criticalCssOptions.url)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test-all": "mocha --compilers js:babel-core/register"
   },
   "dependencies": {
+    "apartment": "1.1.0",
     "css": "2.0.0",
     "css-mediaquery": "^0.1.2",
     "phantomjs": "~1.9.7"


### PR DESCRIPTION
Added `apartment` to remove `animation` and `transition`, including all vendor prefixes and destructured properties.

I was wondering if we could benefit from adding an option that removes a few more properties that don't really affect layouting and could further reduce byte size:

- `::selection`
- `text-shadow`
- `box-shadow`
- `border-radius` properties with `px` values under `50px`
- `pointer-events`
- `cursor` if we want to be super aggressive
- I'm sure there's others