### PR TITLE
Post rm props

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,7 @@ var m = module.exports = function (options, callback) {
 
   cp.on('exit', function (code) {
     if (killTimeout) {
-      clearTimeout(killTimeout);
+      clearTimeout(killTimeout)
     }
     if (code === 0) {
       if (m.DEBUG) {
@@ -125,5 +125,4 @@ var m = module.exports = function (options, callback) {
     cp.kill('SIGTERM')
     process.exit(0)
   })
-
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var path = require('path')
 var spawn = require('child_process').spawn
 var phantomjs = require('phantomjs')
 var phantomJsBinPath = phantomjs.path
+var apartment = require('apartment')
 var configString = ('--config=' + path.join(__dirname, 'phantomjs', 'config.json'))
 var script = path.join(__dirname, 'phantomjs', 'core.js')
 
@@ -90,7 +91,21 @@ var m = module.exports = function (options, callback) {
         console.log('stderr: ' + stdErr)
       }
       stdOut = removePhantomJSSecurityErrors(stdOut)
-      callback(null, stdOut)
+      // remove irrelevant css properties
+      var finalCss = apartment(stdOut, {
+        properties: [
+          '(.*)(animation|transition)(.*)',
+          'cursor',
+          'pointer-events',
+          '(-webkit-)?tap-highlight-color',
+          '(.*)user-select'
+        ],
+        // TODO: move into core phantomjs script
+        selectors: [
+          '::(-moz-)?selection'
+        ]
+      })
+      callback(null, finalCss)
     } else {
       debuggingHelp += 'PhantomJS process exited with code ' + code
       var err = new Error(stdErr + stdOut)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test-all": "mocha --compilers js:babel-core/register"
   },
   "dependencies": {
+    "apartment": "^1.1.0",
     "css": "2.0.0",
     "css-mediaquery": "^0.1.2",
     "phantomjs": "~1.9.7"

--- a/test/static-server/yeoman-medium--expected.css
+++ b/test/static-server/yeoman-medium--expected.css
@@ -4,7 +4,7 @@ body {
 }
 
 
-::selection{color:#fff}ul{list-style:none}
+ul{list-style:none}
 
 .header{
     padding-left: 15px;
@@ -88,8 +88,6 @@ h1 {
 }
 html {
   font-size: 62.5%;
-
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 body {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -162,11 +160,6 @@ ul{
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
-  cursor: pointer;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
   background-image: none;
   border: 1px solid transparent;
   border-radius: 4px;


### PR DESCRIPTION
Re-introduces non critical prop removal as introduced in #100 by @bevacqua. (Was previously reverted as unfortunately latest version of `css` library, which `apartment` uses, cant be used in `phantom`. Now moved outside of phantomjs script.)

Added `user-select` and `tap-highlight-color` to list of props to remove.