### PR TITLE
fix memory leaks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,8 +26,10 @@ var m = module.exports = function (options, callback) {
   var stdOut = '',
     stdErr = '',
     debuggingHelp = '',
-    cp
+    cp,
+    killTimeout
 
+  var timeoutWait = options.timeout || DEFAULT_TIMEOUT
   // need to annotate forceInclude values to allow RegExp to pass through JSON serialization
   var forceInclude = (options.forceInclude || []).map(function (forceIncludeValue) {
     if (typeof forceIncludeValue === 'object' && forceIncludeValue.constructor.name === 'RegExp') {
@@ -73,18 +75,14 @@ var m = module.exports = function (options, callback) {
   })
 
   // kill after timeout
-  var timeout = options.timeout || DEFAULT_TIMEOUT
-  var killTimeout = setTimeout(function () {
-    var msg = 'Penthouse timed out after ' + timeout / 1000 + 's. '
+  killTimeout = setTimeout(function () {
+    var msg = 'Penthouse timed out after ' + timeoutWait / 1000 + 's. '
     debuggingHelp += msg
     stdErr += msg
     cp.kill('SIGTERM')
-  }, timeout)
+  }, timeoutWait)
 
   cp.on('exit', function (code) {
-    if (killTimeout) {
-      clearTimeout(killTimeout)
-    }
     if (code === 0) {
       if (m.DEBUG) {
         console.log('stdout: ' + stdOut)
@@ -115,14 +113,22 @@ var m = module.exports = function (options, callback) {
       err.stderr = stdErr
       callback(err)
     }
-  })
-
-  process.on('exit', function () {
+    // we're done here - clean up
+    clearTimeout(killTimeout)
+    // can't rely on that the parent process will be terminated any time soon,
+    // need to rm listeners and kill child process manually
+    process.removeListener('exit', exitHandler)
+    process.removeListener('SIGTERM', sigtermHandler)
     cp.kill('SIGTERM')
   })
 
-  process.on('SIGTERM', function () {
+  function exitHandler () {
+    cp.kill('SIGTERM')
+  }
+  function sigtermHandler () {
     cp.kill('SIGTERM')
     process.exit(0)
-  })
+  }
+  process.on('exit', exitHandler)
+  process.on('SIGTERM', sigtermHandler)
 }


### PR DESCRIPTION
process event listeners were never cleared explicitly
(only by the parent process exiting), which meant that in long living
node processes all variables in scope were retained forever.