### PR TITLE
Closes #111: allow for configuring phantomjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,12 @@ penthouse({
     ],
     timeout: 30000, // ms; abort critical css generation after this timeout
     strict: false, // set to true to throw on css errors (will run faster if no errors)
-    maxEmbeddedBase64Length: 1000 // charaters; strip out inline base64 encoded resources larger than this
-    userAgent: 'Penthouse Critical Path CSS Generator' // specify which user agent string when loading the page
+    maxEmbeddedBase64Length: 1000, // charaters; strip out inline base64 encoded resources larger than this
+    userAgent: 'Penthouse Critical Path CSS Generator', // specify which user agent string when loading the page
+    phantomJsOptions: { // see `phantomjs --help` for the list of all available options
+      'proxy': 'http://proxy.company.com:8080',
+      'ssl-protocol': 'SSLv3'
+    }
 }, function(err, criticalCss) {
     if (err) { // handle error }
     fs.writeFileSync('outfile.css', criticalCss);

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,15 @@ var removePhantomJSSecurityErrors = function (stdOut) {
   return stdOut
 }
 
+var toPhantomJsOptions = function (maybeOptionsHash) {
+  if (typeof maybeOptionsHash !== 'object') {
+    return [];
+  }
+  return Object.keys(maybeOptionsHash).map(function (optName) {
+    return '--' + optName + '=' + maybeOptionsHash[optName];
+  })
+}
+
 var m = module.exports = function (options, callback) {
   var stdOut = '',
     stdErr = '',
@@ -50,7 +59,11 @@ var m = module.exports = function (options, callback) {
     options.userAgent || DEFAULT_USER_AGENT
   ]
 
-  cp = spawn(phantomJsBinPath, [configString, script].concat(scriptArgs))
+  var phantomJsArgs = [configString].concat(toPhantomJsOptions(options.phantomJsOptions))
+  phantomJsArgs.push(script)
+  phantomJsArgs = phantomJsArgs.concat(scriptArgs)
+
+  cp = spawn(phantomJsBinPath, phantomJsArgs)
 
   // Errors arise before the process starts
   cp.on('error', function (err) {


### PR DESCRIPTION
Allows for passing an additional set of options for phantomjs:

```js
penthouse({
    ...
    phantomJsOptions: { // see `phantomjs --help` for the list of all available options
        'proxy': 'http://proxy.company.com:8080',
        'ssl-protocol': 'SSLv3'
    }
}, ...)
```