### PR TITLE
Wait for condition before generation CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ penthouse({
     maxEmbeddedBase64Length: 1000 // charaters; strip out inline base64 encoded resources larger than this
     userAgent: 'Penthouse Critical Path CSS Generator', // specify which user agent string when loading the page
     generateCssAfter: {  // once the page is loaded, wait for one of the following conditions before processing the css:
-       delay: 1000  // delay in milliseconds, default: 100
+       delay: 1000,  // delay in milliseconds, default: 100
+       elementIsPresent: '#some .css selector'  // an element matching the CSS selector is present in the page
     }
 }, function(err, criticalCss) {
     if (err) { // handle error }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ penthouse({
     timeout: 30000, // ms; abort critical css generation after this timeout
     strict: false, // set to true to throw on css errors (will run faster if no errors)
     maxEmbeddedBase64Length: 1000 // charaters; strip out inline base64 encoded resources larger than this
-    userAgent: 'Penthouse Critical Path CSS Generator' // specify which user agent string when loading the page
+    userAgent: 'Penthouse Critical Path CSS Generator', // specify which user agent string when loading the page
+    generateCssAfter: {  // once the page is loaded, wait for one of the following conditions before processing the css:
+       delay: 1000  // delay in milliseconds, default: 100
+    }
 }, function(err, criticalCss) {
     if (err) { // handle error }
     fs.writeFileSync('outfile.css', criticalCss);

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,8 @@ var m = module.exports = function (options, callback) {
     JSON.stringify(forceInclude), // stringify to maintain array
     !!options.strict,
     typeof options.maxEmbeddedBase64Length === 'number' ? options.maxEmbeddedBase64Length : DEFAULT_MAX_EMBEDDED_BASE64_LENGTH,
-    options.userAgent || DEFAULT_USER_AGENT
+    options.userAgent || DEFAULT_USER_AGENT,
+    JSON.stringify(options.generateCssAfter || {})
   ]
 
   cp = spawn(phantomJsBinPath, [configString, script].concat(scriptArgs))

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -189,7 +189,31 @@ function normalizeCss (css) {
 function pruneNonCriticalCss (astRules, forceInclude, generateCssAfterAsJson, doneStatus) {
   var h = window.innerHeight
   var generateCssAfter = JSON.parse(generateCssAfterAsJson)
-  var renderWaitTime = generateCssAfter.delay || 100
+
+  var createCssGenerationWaitCondition = function () {
+    if (typeof generateCssAfter.elementIsPresent === 'string') {
+      return function () {
+        return document.querySelector(generateCssAfter.elementIsPresent) !== null
+      }
+    }
+
+    var renderWaitTime = generateCssAfter.delay || 100
+    var startTime = Date.now()
+    return function () {
+      return Date.now() - startTime >= renderWaitTime
+    }
+  }
+
+  var executeWhen = function (condition, action) {
+    function executeActionWhenConditionIsTrue() {
+      if (condition()) {
+        return action()
+      }
+      setTimeout(executeActionWhenConditionIsTrue, 50)
+    }
+
+    executeActionWhenConditionIsTrue()
+  }
 
   var isElementAboveFold = function (element) {
     // temporarily force clear none in order to catch elements that clear previous content themselves and who w/o their styles could show up unstyled in above the fold content (if they rely on f.e. 'clear:both;' to clear some main content)
@@ -318,11 +342,12 @@ function pruneNonCriticalCss (astRules, forceInclude, generateCssAfterAsJson, do
     })
   }
 
-  // give some time (renderWaitTime) for sites like facebook that build their page dynamically,
+  // give some time or wait for some element to be present in DOM,
+  // for sites like facebook that build their page dynamically,
   // otherwise we can miss some selectors (and therefor rules)
   // --tradeoff here: if site is too slow with dynamic content,
-  //	it doesn't deserve to be in critical path.
-  setTimeout(processCssRules, renderWaitTime)
+  //	it might not deserve to be in critical path.
+  executeWhen(createCssGenerationWaitCondition(), processCssRules)
 }
 
 /*

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -25,7 +25,8 @@ var criticalCssOptions = {
   forceInclude: [{ value: '*' }].concat(JSON.parse(args[5]) || []),
   strict: args[6] === 'true',
   maxEmbeddedBase64Length: args[7],
-  userAgent: args[8]
+  userAgent: args[8],
+  generateCssAfterAsJson: args[9] || '{}'
 }
 
 var NORMALIZATION_DONE = 'NORMALIZATION_DONE'
@@ -185,9 +186,10 @@ function normalizeCss (css) {
 // called inside a sandboxed environment inside phantomjs - no outside references
 // arguments and return value must be primitives
 // @see http://phantomjs.org/api/webpage/method/evaluate.html
-function pruneNonCriticalCss (astRules, forceInclude, doneStatus) {
+function pruneNonCriticalCss (astRules, forceInclude, generateCssAfterAsJson, doneStatus) {
   var h = window.innerHeight
-  var renderWaitTime = 100 // ms TODO: user specifiable through options object
+  var generateCssAfter = JSON.parse(generateCssAfterAsJson)
+  var renderWaitTime = generateCssAfter.delay || 100
 
   var isElementAboveFold = function (element) {
     // temporarily force clear none in order to catch elements that clear previous content themselves and who w/o their styles could show up unstyled in above the fold content (if they rely on f.e. 'clear:both;' to clear some main content)
@@ -346,7 +348,7 @@ function getCriticalPathCss (options) {
       errorlog("Error opening url '" + page.reason_url + "': " + page.reason)
       phantomExit(1)
     } else {
-      page.evaluate(pruneNonCriticalCss, astRules, options.forceInclude, GENERATION_DONE)
+      page.evaluate(pruneNonCriticalCss, astRules, options.forceInclude, options.generateCssAfterAsJson, GENERATION_DONE)
     }
   })
 }

--- a/test/core-tests.js
+++ b/test/core-tests.js
@@ -309,4 +309,24 @@ describe('penthouse core tests', function () {
       }
     })
   })
+
+  it('should wait for some element to be present before generating critical css', function (done) {
+    penthouse({
+      url: path.join(__dirname, 'static-server', 'page-taking-too-long-to-display.html'),
+      css: page1cssPath,
+      generateCssAfter: {
+        elementIsPresent: '#box22'
+      }
+    }, function (err, result) {
+      if (err) {
+        done(err);
+      }
+      try {
+        result.should.contain('#box22')
+        done()
+      } catch (ex) {
+        done(ex)
+      }
+    })
+  })
 })

--- a/test/core-tests.js
+++ b/test/core-tests.js
@@ -289,4 +289,24 @@ describe('penthouse core tests', function () {
     smallViewportRules.should.have.length(0)
     done()
   })
+
+  it('should wait for requested time before generating critical css', function (done) {
+    penthouse({
+      url: path.join(__dirname, 'static-server', 'page-taking-too-long-to-display.html'),
+      css: page1cssPath,
+      generateCssAfter: {
+        delay: 300
+      }
+    }, function (err, result) {
+      if (err) {
+        done(err);
+      }
+      try {
+        result.should.contain('#box22')
+        done()
+      } catch (ex) {
+        done(ex)
+      }
+    })
+  })
 })

--- a/test/static-server/page-taking-too-long-to-display.html
+++ b/test/static-server/page-taking-too-long-to-display.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+    <link rel="stylesheet" href="page1.css"/>
+</head>
+<body>
+<script>
+    setTimeout(function () {
+        document.body.innerHTML = '' +
+            '<div id="box1">Box 1' +
+                '<div id="box11">Box 1.1</div>' +
+            '</div>' +
+            '<div id="box2">Box 2' +
+                '<div id="box21">Box 2.1</div>' +
+                '<div id="box22">Box 2.2</div>' +
+            '</div>';
+    }, 150);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Allow for configuring how penthouse wait for the page to be ready before generating the CSS, either by specifying a delay, or an element that should be present in the page:

```js
penthouse({
    generateCssAfter: {  // once the page is loaded, wait for one of the following conditions before processing the css:
         delay: 1000,  // delay in milliseconds
         elementIsPresent: '#some .css selector'  // an element matching the CSS selector is present in the page
    }
}, ...);
```
