### PR TITLE
Normalising perf improvements

### DIFF
--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -16,6 +16,8 @@ if (args.length < 4) {
   phantomExit(1)
 }
 
+var START_TIME
+
 var criticalCssOptions = {
   url: args[1],
   css: args[2],
@@ -38,7 +40,7 @@ var combineArgsString = function (argsArr) {
 // monkey patch for directing errors to stderr
 // https://github.com/ariya/phantomjs/issues/10150#issuecomment-28707859
 var errorlog = function () {
-  system.stderr.write(combineArgsString(arguments))
+  system.stderr.write('time: ' + (new Date().getTime() - START_TIME) + ' | ' + combineArgsString(arguments))
 }
 
 function prepareNewPage () {
@@ -49,6 +51,10 @@ function prepareNewPage () {
   /* prevent page JS errors from being output to final CSS */
   page.onError = function (msg, trace) {
     // do nothing
+  }
+
+  page.onConsoleMessage = function(msg, lineNum, sourceId) {
+    errorlog(msg)
   }
 
   page.onResourceRequested = function (requestData, request) {
@@ -63,21 +69,26 @@ function prepareNewPage () {
   }
   page.onCallback = function (callbackObject) {
     if (callbackObject.status === NORMALIZATION_DONE) {
+      errorlog('NORMALIZATION_DONE')
       // because otherwise the actual url we want to open a page with will open with
       // content set in normalizeCss..
       prepareNewPage()
+      errorlog('NORMALIZATION_DONE, prepareNewPage done')
       criticalCssOptions.ast = cssAstFormatter.parse(callbackObject.css, { silent: true })
+      errorlog('NORMALIZATION_DONE, got ast')
       getCriticalPathCss(criticalCssOptions)
       return
     }
 
     if (callbackObject.status === GENERATION_DONE) {
+      errorlog('GENERATION_DONE')
       returnCssFromAstRules(callbackObject.rules)
     }
   }
 }
 
 function returnCssFromAstRules (criticalRules) {
+  errorlog('returnCssFromAstRules')
   try {
     if (criticalRules && criticalRules.length > 0) {
       var finalCss = cssAstFormatter.stringify({
@@ -85,13 +96,16 @@ function returnCssFromAstRules (criticalRules) {
           rules: criticalRules
         }
       })
+      errorlog('finalCss: stringify from ast')
 
       // remove data-uris that are too long
       // ..faster if this removal can be combined with @font-face one into same iteration..
       finalCss = embeddedbase64Remover(finalCss, criticalCssOptions.maxEmbeddedBase64Length)
+      errorlog('finalCss: embeddedbase64Remover')
 
       // remove unused @fontface rules
       finalCss = ffRemover(finalCss)
+      errorlog('finalCss: ffRemover')
 
       // TODO: bring handleRuleSelectorCase func back, was removed because was too slow
       // previous version of Penthouse ensured selector case in return critiacl css was the same.
@@ -103,6 +117,7 @@ function returnCssFromAstRules (criticalRules) {
 
       // return the critical css!
       stdout.write(finalCss)
+      errorlog('finalCss: write - DONE!')
       phantomExit(0)
     } else {
       // No css. This is not an error on our part
@@ -129,6 +144,7 @@ function phantomExit (code) {
 }
 
 function extractFullCssFromPage (doneStatus, originalCss) {
+  console.log('extractFullCssFromPage')
   var getOriginalSelectorCase = function (selector) {
     var sanitizedSelector = selector.replace(/[#-.]|[[-^]|[?|{}]/g, '\\$&')
     var pattern = new RegExp('(' + sanitizedSelector + ')[ ,{]?', 'i') // }
@@ -154,13 +170,17 @@ function extractFullCssFromPage (doneStatus, originalCss) {
   }
 
   originalCss = decodeURIComponent(originalCss)
-  var css = Array.prototype.map.call(document.styleSheets, function (stylesheet) {
+  console.log('extractFullCssFromPage :' + originalCss.length)
+  var css = Array.prototype.map.call(document.styleSheets, function (stylesheet, idx) {
     return handleCssRules(stylesheet.cssRules)
   }).join(' ')
+
+  console.log('extractFullCssFromPage, css extracted :' + css.length)
 
   // these (case 0) @-rules are not part of document.styleSheets, so need to be preserved manually
   var metaMatches = originalCss.match(/(@(import|namespace)[^;]*;)/g)
   if (metaMatches) {
+    console.log('extractFullCssFromPage, metamatches')
     // preserve order
     var metaCss = ''
     metaMatches.forEach(function (metaMatch) {
@@ -168,6 +188,7 @@ function extractFullCssFromPage (doneStatus, originalCss) {
     })
     css = metaCss + css
   }
+  console.log('extractFullCssFromPage, metamatches DONE, callPhantom')
   window.callPhantom({
     status: doneStatus,
     css: css
@@ -175,7 +196,9 @@ function extractFullCssFromPage (doneStatus, originalCss) {
 }
 
 function normalizeCss (css) {
+  errorlog('normalizeCss: ' + css.length)
   page.content = '<html><head><style>' + css + '</style></head><body></body></html>'
+  errorlog('normalizeCss: set content, now extractFullCssFromPage')
   page.evaluate(extractFullCssFromPage, NORMALIZATION_DONE, encodeURIComponent(css))
 }
 
@@ -183,6 +206,7 @@ function normalizeCss (css) {
 // arguments and return value must be primitives
 // @see http://phantomjs.org/api/webpage/method/evaluate.html
 function pruneNonCriticalCss (astRules, forceInclude, doneStatus) {
+  console.log('pruneNonCriticalCss')
   var h = window.innerHeight
   var renderWaitTime = 100 // ms TODO: user specifiable through options object
 
@@ -304,7 +328,9 @@ function pruneNonCriticalCss (astRules, forceInclude, doneStatus) {
   }
 
   var processCssRules = function () {
+    console.log('processCssRules BEFORE')
     var criticalRules = astRules.filter(isCssRuleCritical)
+    console.log('processCssRules AFTER')
 
     // we're done - call final function to exit outside of phantom evaluate scope
     window.callPhantom({
@@ -331,41 +357,50 @@ function pruneNonCriticalCss (astRules, forceInclude, doneStatus) {
  * @param options.height the height of viewport
  ---------------------------------------------------------*/
 function getCriticalPathCss (options) {
+  errorlog('getCriticalPathCss')
   page.viewportSize = {
     width: options.width,
     height: options.height
   }
   // first strip out non matching media queries
   var astRules = nonMatchingMediaQueryRemover(options.ast.stylesheet.rules, options.width, options.height)
+  errorlog('stripped out non matching media queries')
 
   page.open(options.url, function (status) {
     if (status !== 'success') {
       errorlog("Error opening url '" + page.reason_url + "': " + page.reason)
       phantomExit(1)
     } else {
+      errorlog('page opened')
       page.evaluate(pruneNonCriticalCss, astRules, options.forceInclude, GENERATION_DONE)
     }
   })
 }
 
+START_TIME = new Date().getTime()
+errorlog('START_TIME: ' + START_TIME)
 var css
 try {
   var f = fs.open(criticalCssOptions.css, 'r')
   css = f.read()
+  errorlog('opened css')
 } catch (e) {
   errorlog(e)
   phantomExit(1)
 }
 
 prepareNewPage()
+errorlog('prepared new page')
 var ast
 try {
   ast = cssAstFormatter.parse(css)
+  errorlog('parsed ast (without errores)')
 } catch (e) {
   if (criticalCssOptions.strict) {
     errorlog(e.message)
     phantomExit(1)
   }
+  errorlog("Failed ast formatting css '" + e.message + "': ")
   normalizeCss(css)
 }
 

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -93,6 +93,10 @@ function returnCssFromAstRules (criticalRules) {
       // remove unused @fontface rules
       finalCss = ffRemover(finalCss)
 
+      // TODO: bring handleRuleSelectorCase func back, was removed because was too slow
+      // previous version of Penthouse ensured selector case in return critiacl css was the same.
+      // (it gets modified (transformed to lowercase) when normalized)
+
       if (finalCss.trim().length === 0) {
         errorlog('Note: Generated critical css was empty for URL: ' + criticalCssOptions.url)
       }
@@ -134,13 +138,6 @@ function extractFullCssFromPage (doneStatus, originalCss) {
     }
     return selector
   }
-  // can't just return rule.cssText here, because these selectors are forced lowercase (in Chrome),
-  // but querySelectorAll is case sensitive (for selectors containing certain reserved words, such as float)
-  // therefor need to go back to original styles and grab original (case) name for each selector..
-  var handleRuleSelectorCase = function (cssStyleRule) {
-    var selectors = cssStyleRule.selectorText.split(',').map(getOriginalSelectorCase).join(',')
-    return selectors + '{' + cssStyleRule.style.cssText + '}'
-  }
 
   var handleCssRule = function (rule) {
     if (!rule.selectorText) {
@@ -150,7 +147,7 @@ function extractFullCssFromPage (doneStatus, originalCss) {
       var mediaContent = handleCssRules(rule.cssRules)
       return '@media ' + rule.media.mediaText + '{' + mediaContent + '}'
     }
-    return handleRuleSelectorCase(rule)
+    return rule.cssText
   }
   var handleCssRules = function (cssRulesList) {
     return Array.prototype.map.call(cssRulesList || [], handleCssRule).join(' ')

--- a/test/static-server/yeoman-full--invalid.css
+++ b/test/static-server/yeoman-full--invalid.css
@@ -12,7 +12,7 @@ body {
 }
 .header,
 .marketing{
-    padding-left: 15px;
+    padding-left: 15px;// planted to test breakage
     padding-right: 15px;
 }
 


### PR DESCRIPTION
Drastic improvement, execution time saving of about 80% for _invalid_ css files! 💥 

Did some profiling and found that the function for returning css selector case to original after getting it back in lower base via the browser in the css normalisation handling takes an enormous amount of time to run, f.e. 40/48s for a 1.2MB example css file I was running with.

.. so disabling it for now.

If wanting to bring it back in the future: put it _outside_ of page.evaluate loops, and profile!  But first make sure it's actually needed, not sure I got that right last time.

--

Also added profiling logs to Penthouse, now spitted out to stdout.