### PR TITLE
Fix fonticons in normalise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,6 @@ var m = module.exports = function (options, callback) {
 
   cp.stdout.on('data', function (data) {
     stdOut += data
-    if (m.DEBUG) { console.log('' + data) }
   })
 
   cp.stderr.on('data', function (data) {
@@ -100,10 +99,6 @@ var m = module.exports = function (options, callback) {
 
   cp.on('exit', function (code) {
     if (code === 0) {
-      if (m.DEBUG) {
-        console.log('stdout: ' + stdOut)
-        console.log('stderr: ' + stdErr)
-      }
       stdOut = removePhantomJSSecurityErrors(stdOut)
       // remove irrelevant css properties
       var finalCss = apartment(stdOut, {

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -60,7 +60,7 @@ function prepareNewPage () {
     // do nothing
   }
 
-  page.onConsoleMessage = function(msg) {
+  page.onConsoleMessage = function (msg) {
     debuglog(msg)
   }
 
@@ -152,15 +152,6 @@ function phantomExit (code) {
 
 function extractFullCssFromPage (doneStatus, originalCss) {
   console.log('extractFullCssFromPage')
-  var getOriginalSelectorCase = function (selector) {
-    var sanitizedSelector = selector.replace(/[#-.]|[[-^]|[?|{}]/g, '\\$&')
-    var pattern = new RegExp('(' + sanitizedSelector + ')[ ,{]?', 'i') // }
-    var match = originalCss.match(pattern)
-    if (match && match[1]) {
-      return match[1]
-    }
-    return selector
-  }
 
   var handleCssRule = function (rule) {
     if (!rule.selectorText) {

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -200,8 +200,12 @@ function extractFullCssFromPage (doneStatus, originalCss) {
 function normalizeCss (css) {
   debuglog('normalizeCss: ' + css.length)
   // need to escape hex referenced unicode chars in content:'' declarations,
-  // because otherwise they get lost when extracting from browser in normalising step.
-  // use jsesc library for this.
+  // otherwise they get lost when extracting from browser in normalising step.
+  // Using jsesc library for this.
+  // NOTE: alternative solution:
+  // check length of matched innerContent,
+  // if 1, just take charcodeAt(0).toString(16) and prepend '\'
+  // otherwise if starts with `\`, add another one
   css = css.replace(/(content\s*:\s*)(['"])([^'"]*)(['"])/g, function (match, pre, quote, innerContent, quote2) {
     if (quote !== quote2) {
       return

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -8,6 +8,7 @@ var cssAstFormatter = require('css'),
   system = require('system'),
   stdout = system.stdout, // for using this as a file
   webpage = require('webpage'),
+  jsesc = require('jsesc'),
   page // initialised in prepareNewPage
 
 var NORMALIZATION_DONE = 'NORMALIZATION_DONE'
@@ -175,6 +176,9 @@ function extractFullCssFromPage (doneStatus, originalCss) {
 
   console.log('extractFullCssFromPage, css extracted :' + css.length)
 
+  // Chrome returns all strings as single quotes, so don't need to look for double quotes
+  css = css.replace(/'\\\\/g, '\'\\')
+
   // these (case 0) @-rules are not part of document.styleSheets, so need to be preserved manually
   var metaMatches = originalCss.match(/(@(import|namespace)[^;]*;)/g)
   if (metaMatches) {
@@ -195,6 +199,28 @@ function extractFullCssFromPage (doneStatus, originalCss) {
 
 function normalizeCss (css) {
   debuglog('normalizeCss: ' + css.length)
+  // need to escape hex referenced unicode chars in content:'' declarations,
+  // because otherwise they get lost when extracting from browser in normalising step.
+  // use jsesc library for this.
+  css = css.replace(/(content\s*:\s*)(['"])([^'"]*)(['"])/g, function (match, pre, quote, innerContent, quote2) {
+    if (quote !== quote2) {
+      return
+    }
+    return pre + quote + jsesc(innerContent) + quote
+  })
+  // .. however it's not perfect for our needs,
+  // as we need to be able to convert back to CSS acceptable format.
+  // i.e. need to go from `\f` to `\\f` (and then back afterwards),
+  // and need to use `\2022` rather than `u2022`...
+  // this is not rigourously tested and not following any spec, needs to be improved.
+  .replace(/(['"])(\\)([^\\])/g, function (match, quote, slash, firstInnerContentChar) {
+    if (firstInnerContentChar === 'u') {
+      return quote + slash + slash
+    }
+    return quote + slash + slash + firstInnerContentChar
+  })
+
+  debuglog('escaped hex in normalizeCss')
   page.content = '<html><head><style>' + css + '</style></head><body></body></html>'
   page.evaluate(extractFullCssFromPage, NORMALIZATION_DONE, encodeURIComponent(css))
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "apartment": "^1.1.1",
     "css": "2.0.0",
     "css-mediaquery": "^0.1.2",
+    "jsesc": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "phantomjs-prebuilt": "^2.1.3"
   },
   "devDependencies": {
-    "babel-core": "^6.4.5",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-core": "^6.8.0",
+    "babel-preset-es2015": "^6.6.0",
     "chai": "^1.9.1",
     "css-compare-screenshots": "0.0.7",
     "express": "^4.4.2",

--- a/test/core-tests.js
+++ b/test/core-tests.js
@@ -12,7 +12,7 @@ import nonMatchingMediaQueryRemover from '../lib/phantomjs/non-matching-media-qu
 
 process.setMaxListeners(0)
 
-// becasuse dont want to fail tests on white space differences
+// because dont want to fail tests on white space differences
 function normalisedCssAst (cssString) {
   return css.parse(css.stringify(css.parse(cssString), { compress: true }))
 }

--- a/test/normalising-css-tests.js
+++ b/test/normalising-css-tests.js
@@ -6,14 +6,51 @@ import rimraf from 'rimraf'
 
 import compareScreenshots from './util/compareScreenshots'
 
+import css from 'css'
+import fs from 'fs'
+import chai from 'chai'
+chai.should() // binds globally on Object
+
 const SCREENSHOT_DIST = path.join(__dirname, '/results/')
 const STATIC_SERVER_PATH = path.join(__dirname, 'static-server')
+
+// because dont want to fail tests on white space differences
+function normalisedCssAst (cssString) {
+  return css.parse(css.stringify(css.parse(cssString), { compress: true }))
+}
 
 describe('penthouse fault tolerant normalising css tests', function () {
   after(function () {
     rimraf.sync(SCREENSHOT_DIST.replace(/\/$/, ''))
   })
   this.timeout(20000)
+
+  it('should preserve escaped hex reference styles', function (done) {
+    // NOTE: the normalised CSS comes back with all quotes (for escaped hex refs only?)
+    // as single quotes, regardless of what they were before.
+    // This test will fail if the css uses double quotes (although false negative: still works)
+    const cssPath = path.join(STATIC_SERVER_PATH, 'escaped-hex-reference-in-invalid.css')
+    const expected = fs.readFileSync(cssPath, 'utf8').replace('{ invalid }', '')
+    penthouse.DEBUG = false
+    penthouse({
+      url: path.join(STATIC_SERVER_PATH, 'page1.html'),
+      css: cssPath
+    }, function (err, result) {
+      if (err) {
+        done(err)
+      }
+      const resultAst = normalisedCssAst(
+        // because Chrome returns single quotes
+        result.replace(/"/g, '\'')
+      )
+      const expectedAst = normalisedCssAst(
+        // because too lazy to create separate 'original' and 'expected' stylesheets (• -> \u2022)
+        expected.replace(/['"]•['"]/g, '\'\\2022\'')
+      )
+      resultAst.should.eql(expectedAst)
+      done()
+    })
+  })
 
   it('should generate same layout for yemoan with css errors', function (done) {
     const screenshotFilename = 'yeoman'

--- a/test/static-server/escaped-hex-reference-in-invalid.css
+++ b/test/static-server/escaped-hex-reference-in-invalid.css
@@ -1,0 +1,19 @@
+body::before {
+  content: '\f091';
+}
+body::before {
+  content: '\e5';
+}
+body::after {
+  content: '\f09a';
+}
+body::after {
+  content: '•';
+}
+body::after {
+  content: "•";
+}
+body::after {
+  content: '\2022';
+}
+{ invalid }


### PR DESCRIPTION
`Content: ''"` for font icons and other special characters were getting lost through normalization process (when css has errors), due to lack of escaping. This leas to font-icons never rendering with critical css, even if font was loaded.
This should fix that, although the fix is not super clean, and probably doesn't cover all cases. The important bit is very popular font icons, which should work now, even it the css has (other) errors.