### PR TITLE
use os independent tmp directory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ var phantomjs = require('phantomjs-prebuilt')
 var phantomJsBinPath = phantomjs.path
 var apartment = require('apartment')
 var cssAstFormatter = require('css')
+var osTmpdir = require('os-tmpdir')
 var postformatting = require('./postformatting/')
 var normalizeCss = require('./normalize-css')
 
@@ -22,6 +23,7 @@ var DEFAULT_VIEWPORT_HEIGHT = 900 // px
 var DEFAULT_TIMEOUT = 30000 // ms
 var DEFAULT_MAX_EMBEDDED_BASE64_LENGTH = 1000 // chars
 var DEFAULT_USER_AGENT = 'Penthouse Critical Path CSS Generator'
+var TMP_DIR = osTmpdir()
 
 var toPhantomJsOptions = function (maybeOptionsHash) {
   if (typeof maybeOptionsHash !== 'object') {
@@ -53,7 +55,7 @@ function penthouseScriptArgs (options, ast) {
 
 function writeAstToFile (ast) {
   // save ast to file
-  var tmpobj = tmp.fileSync({dir: '/tmp'})
+  var tmpobj = tmp.fileSync({dir: TMP_DIR})
   fs.writeFileSync(tmpobj.name, JSON.stringify(ast))
   return tmpobj.name
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "css": "git://github.com/pocketjoso/css.git",
     "css-mediaquery": "^0.1.2",
     "jsesc": "^1.0.0",
+    "os-tmpdir": "^1.0.1",
     "phantomjs-prebuilt": "^2.1.3",
     "tmp": "0.0.28"
   },


### PR DESCRIPTION
Currently penthouse is not working on windows due to the hard-coded `/tmp` directory.
See: https://github.com/addyosmani/critical/issues/149

