### PR TITLE
Remove unused devDependencies and normalize package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "license": "MIT",
   "main": "./lib/index.js",
+  "engines": {
+    "node": ">=0.12.0"
+  },
   "scripts": {
     "lint": "jshint .",
     "test": "npm run lint && mocha --compilers js:babel-core/register test/core-tests.js",
@@ -49,5 +52,8 @@
     "performance",
     "build",
     "tool"
+  ],
+  "files": [
+    "lib/**/*.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -36,16 +36,11 @@
     "babel-preset-es2015": "^6.6.0",
     "chai": "^1.9.1",
     "css-compare-screenshots": "0.0.7",
-    "express": "^4.4.2",
     "global-mocha": "^1.0.1",
     "gm": "^1.21.1",
-    "grunt": "~0.4.2",
     "jshint": "^2.9.3",
     "mocha": "^1.20.1",
-    "morgan": "^1.1.1",
-    "portfinder": "^0.2.1",
-    "rimraf": "^2.4.3",
-    "shelljs": "^0.3.0"
+    "rimraf": "^2.4.3"
   },
   "keywords": [
     "CSS Critical Path Generator",


### PR DESCRIPTION
@pocketjoso: there seems to be more dev deps unused like express, morgan and portfinder. Should I remove those too?