### PR TITLE
prevent css parse to throw on errors after normalising

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -230,8 +230,15 @@ var m = module.exports = function (options, callback) { // jshint ignore: line
         normalizeScriptArgs,
         function (err, normalizedCss) {
           debuglog('normalized css: ' + normalizedCss.length)
-          ast = cssAstFormatter.parse(normalizedCss)
+          ast = cssAstFormatter.parse(normalizedCss, { silent: true })
           debuglog('parsed normalised css into ast')
+          var parsingErrors = ast.stylesheet.parsingErrors.filter(function (err) {
+            // the forked version of the astParser used fixes these errors itself
+            return err.reason !== 'Extra closing brace'
+          })
+          if (parsingErrors.length > 0) {
+            debuglog('..with parsingErrors: ' + parsingErrors[0].reason)
+          }
           resolve(ast)
           return
         }


### PR DESCRIPTION
Apparently there is some css syntax that the `css.parse` method finds illegal that comes through the normalisation step, which caused an uncaught error to be thrown. This error is now caught instead. (except for in `strict` mode - where normalisation is not attempted at all).