### PR TITLE
quote font-face format values in normalized css

### DIFF
--- a/lib/phantomjs/normalize-css.js
+++ b/lib/phantomjs/normalize-css.js
@@ -92,6 +92,9 @@ function extractFullCssFromPage (originalCss) {
   function handleCssRule (rule) {
     if (!rule.selectorText) {
       if (!rule.media) {
+        if (rule.cssText.indexOf('@font-face') !== -1) {
+          return rule.cssText.replace(/format\(([^'")]*)\)/g, 'format(\'$1\')')
+        }
         return rule.cssText
       }
       var mediaContent = handleCssRules(rule.cssRules)


### PR DESCRIPTION
for some reason the 'format("woff")' parts of @font-face src declarations
come back without the quotes, which makes them invalid,
and causing the font-face to not work, at least not in some browsers
(latest Chrome f.e.).

To circumvent this, re-apply the missing quotes.