### PR TITLE
Optional unblock js requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ penthouse({
     strict: false,                  // set to true to throw on CSS errors (will run faster if no errors)
     maxEmbeddedBase64Length: 1000,  // characters; strip out inline base64 encoded resources larger than this
     userAgent: 'Penthouse Critical Path CSS Generator', // specify which user agent string when loading the page
+    renderWaitTime: 100,            // ms; render wait timeout before CSS processing starts (default: 100)
+    blockJSRequests: true,          // set to false to load (external) JS (default: true)
     phantomJsOptions: {             // see `phantomjs --help` for the list of all available options
       'proxy': 'http://proxy.company.com:8080',
       'ssl-protocol': 'SSLv3'

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ var DEFAULT_MAX_EMBEDDED_BASE64_LENGTH = 1000 // chars
 var DEFAULT_USER_AGENT = 'Penthouse Critical Path CSS Generator'
 var TMP_DIR = osTmpdir()
 var DEFAULT_RENDER_WAIT_TIMEOUT = 100
+var DEFAULT_BLOCK_JS_REQUESTS = true
 
 var toPhantomJsOptions = function (maybeOptionsHash) {
   if (typeof maybeOptionsHash !== 'object') {
@@ -53,6 +54,7 @@ function penthouseScriptArgs (options, ast) {
     JSON.stringify(forceInclude), // stringify to maintain array
     options.userAgent || DEFAULT_USER_AGENT,
     options.renderWaitTime || DEFAULT_RENDER_WAIT_TIMEOUT,
+    (typeof options.blockJSRequests !== 'undefined' ? options.blockJSRequests : DEFAULT_BLOCK_JS_REQUESTS),
     m.DEBUG
   ]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ var DEFAULT_TIMEOUT = 30000 // ms
 var DEFAULT_MAX_EMBEDDED_BASE64_LENGTH = 1000 // chars
 var DEFAULT_USER_AGENT = 'Penthouse Critical Path CSS Generator'
 var TMP_DIR = osTmpdir()
+var DEFAULT_RENDER_WAIT_TIMEOUT = 100
 
 var toPhantomJsOptions = function (maybeOptionsHash) {
   if (typeof maybeOptionsHash !== 'object') {
@@ -51,6 +52,7 @@ function penthouseScriptArgs (options, ast) {
     options.height || DEFAULT_VIEWPORT_HEIGHT,
     JSON.stringify(forceInclude), // stringify to maintain array
     options.userAgent || DEFAULT_USER_AGENT,
+    options.renderWaitTime || DEFAULT_RENDER_WAIT_TIMEOUT,
     m.DEBUG
   ]
 }

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -26,7 +26,8 @@ var criticalCssOptions = {
   // always forceInclude '*' selector
   forceInclude: [{ value: '*' }].concat(JSON.parse(args[5]) || []),
   userAgent: args[6],
-  debugMode: args[7] === 'true'
+  renderWaitTime: parseInt(args[7], 10),
+  debugMode: args[8] === 'true'
 }
 
 function debuglog (msg, isError) {
@@ -114,10 +115,9 @@ function phantomExit (code) {
 // called inside a sandboxed environment inside phantomjs - no outside references
 // arguments and return value must be primitives
 // @see http://phantomjs.org/api/webpage/method/evaluate.html
-function pruneNonCriticalCss (astRules, forceInclude, doneStatus) {
+function pruneNonCriticalCss (astRules, forceInclude, renderWaitTime, doneStatus) {
   console.log('debug: pruneNonCriticalCss')
   var h = window.innerHeight
-  var renderWaitTime = 100 // ms TODO: user specifiable through options object
 
   var isElementAboveFold = function (element) {
     // temporarily force clear none in order to catch elements that clear previous content themselves and who w/o their styles could show up unstyled in above the fold content (if they rely on f.e. 'clear:both;' to clear some main content)
@@ -282,7 +282,7 @@ function getCriticalPathCss (options) {
   page.open(options.url, function (status) {
     if (status === 'success') {
       debuglog('page opened')
-      page.evaluate(pruneNonCriticalCss, astRules, options.forceInclude, GENERATION_DONE)
+      page.evaluate(pruneNonCriticalCss, astRules, options.forceInclude, options.renderWaitTime, GENERATION_DONE)
     } else {
       errorlog('Error opening url \'' + page.reason_url + '\': ' + page.reason) // jshint ignore: line
       phantomExit(1)

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -67,7 +67,7 @@ function prepareNewPage () {
   }
 
   page.onResourceRequested = function (requestData, request) {
-    if (criticalCssOptions.blockJSRequests != 'false' && /\.js(\?.*)?$/.test(requestData.url)) {
+    if (criticalCssOptions.blockJSRequests !== 'false' && /\.js(\?.*)?$/.test(requestData.url)) {
       request.abort()
     }
   }

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -27,7 +27,8 @@ var criticalCssOptions = {
   forceInclude: [{ value: '*' }].concat(JSON.parse(args[5]) || []),
   userAgent: args[6],
   renderWaitTime: parseInt(args[7], 10),
-  debugMode: args[8] === 'true'
+  blockJSRequests: args[8],
+  debugMode: args[9] === 'true'
 }
 
 function debuglog (msg, isError) {
@@ -66,7 +67,7 @@ function prepareNewPage () {
   }
 
   page.onResourceRequested = function (requestData, request) {
-    if (/\.js(\?.*)?$/.test(requestData.url)) {
+    if (criticalCssOptions.blockJSRequests != 'false' && /\.js(\?.*)?$/.test(requestData.url)) {
       request.abort()
     }
   }


### PR DESCRIPTION
Add blockJSRequests option (default = true).

Makes it possible to load JS files. See discussion here: https://github.com/pocketjoso/penthouse/issues/113
Made it optional. Choice = good, even if it might be wasteful :)