### PR TITLE
Update 'tmp' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jsesc": "^1.0.0",
     "os-tmpdir": "^1.0.1",
     "phantomjs-prebuilt": "^2.1.3",
-    "tmp": "0.0.28"
+    "tmp": "0.0.31"
   },
   "devDependencies": {
     "babel-core": "^6.8.0",


### PR DESCRIPTION
The used tmp library in version 0.0.28 has at least one critical bug in it, updating it solves everything like:
ReferenceError: c is not defined
    at _removeCallback (/var/app/current/node_modules/penthouse/node_modules/tmp/lib/tmp.js:355:47)
    at Object._cleanupCallback [as removeCallback] (/var/app/current/node_modules/penthouse/node_modules/tmp/lib/tmp.js:409:5)
    at ChildProcess. (/var/app/current/node_modules/penthouse/lib/index.js:186:17)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
    at Process.onexit (/var/app/current/node_modules/async-listener/glue.js:188:31)