### PR TITLE
Make babel-polyfill Regular Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "apartment": "^1.1.1",
+    "babel-polyfill": "^6.23.0",
     "css": "https://github.com/pocketjoso/css.git",
     "css-mediaquery": "^0.1.2",
     "jsesc": "^1.0.0",
@@ -46,7 +47,6 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.4.0",
     "babel-preset-es2015": "^6.24.1",
     "chai": "^1.9.1",


### PR DESCRIPTION
Had some issues sometime after the 0.11.0 update because babel-polyfill couldn't be found. Should just need to be moved from dev deps to regular deps.

Let me know if I'm mistaken or missed anything.