### PR TITLE
Replace babel-polyfill with regenerator-runtime

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+    "env": {
+        "node": true,
+        "es6": true
+    },
+    "rules": {
+        "semi": "never"
+    }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
 
-require('babel-polyfill'); // support Node 4
+require('regenerator-runtime/runtime'); // support Node 4
 
 var fs = require('fs');
 var tmp = require('tmp');

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
   },
   "dependencies": {
     "apartment": "^1.1.1",
-    "babel-polyfill": "^6.23.0",
     "css": "https://github.com/pocketjoso/css.git",
     "css-mediaquery": "^0.1.2",
     "jsesc": "^1.0.0",
     "os-tmpdir": "^1.0.1",
     "phantomjs-prebuilt": "^2.1.3",
+    "regenerator-runtime": "^0.10.5",
     "tmp": "0.0.31"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
  */
 
 'use strict'
-require('babel-polyfill') // support Node 4
+require('regenerator-runtime/runtime') // support Node 4
 
 const fs = require('fs')
 const tmp = require('tmp')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2898,7 +2898,7 @@ regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
 
-regenerator-runtime@^0.10.0:
+regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 


### PR DESCRIPTION
So, for kicks and giggles I was trying out Node 8.0 on my machine (I know, I know… it's not even LTS yet), but found that everything was working fine with my build system except for penthouse. So dug in and found that the only issue was babel-polyfill seemingly not working, and that since really the only reason it was (apparently) being pulled in for was `regeneratorRuntime`, using the regenerator-runtime was an easy fix.

It also has the added bonus of being much lighter weight, since you don't have to pull in all of the extra polyfill stuff. And as an added bonus, you look to be set for Node 8.0 with this change.

Also, was having some issues with my own .eslintrc rules bubbling up into the prettier-standard call and adding semicolons to everything—so also added a local .eslintrc file which will be helpful for any other contributors. Wasn't sure what you're rules look like, so simply added the only one that was needed to keep my rules from changing any of your styles.