### PR TITLE
Assign Local regeneratorRuntime Variable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
 
-require('regenerator-runtime/runtime'); // support Node 4
+var regeneratorRuntime = require('regenerator-runtime/runtime'); // eslint-disable-line no-unused-vars
 
 var fs = require('fs');
 var tmp = require('tmp');

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
  */
 
 'use strict'
-require('regenerator-runtime/runtime') // support Node 4
+const regeneratorRuntime = require('regenerator-runtime/runtime') // eslint-disable-line no-unused-vars
 
 const fs = require('fs')
 const tmp = require('tmp')


### PR DESCRIPTION
So, interestingly enough, everything worked with the local copy before but after pushing everything to npm and using the published version, it seems that for some reason that regeneratorRuntime is not showing up in the global scope as expected. 

Originally didn't assign it locally because prettier-standard was throwing a no-unused-vars error (prob just because of my own eslint rules), but just disabled that error for that line and actually tested it by pulling from my repo after instead of linking to the local copy.

Sorry for the faulty PR previously. 😓