### PR TITLE
Perf improvents

### DIFF
--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -131,11 +131,28 @@ function pruneNonCriticalCss(astRules, forceInclude, renderWaitTime, doneStatus)
   // we will replace all instances of these psuedo selectors; hence global flag
   var PSUEDO_SELECTOR_REGEXP = new RegExp(psuedoSelectorsToKeepRegex, 'g');
 
+  // cache whether elements are above fold,
+  // primarily because getBoundingClientRect() can be slow to query,
+  // and some stylesheets have lots of generic selectors (like '.button', '.fa' etc)
+  var isElementAboveFoldCache = [];
   var isElementAboveFold = function isElementAboveFold(element) {
+    // no support for Array.find
+    var matching = isElementAboveFoldCache.filter(function (c) {
+      return c.element === element;
+    });
+    var cached = matching && matching[0];
+    if (cached) {
+      return cached.aboveFold;
+    }
     // temporarily force clear none in order to catch elements that clear previous content themselves and who w/o their styles could show up unstyled in above the fold content (if they rely on f.e. 'clear:both;' to clear some main content)
     var originalClearStyle = element.style.clear || '';
     element.style.clear = 'none';
     var aboveFold = element.getBoundingClientRect().top < h;
+    // cache so we dont have to re-query dom for this value
+    isElementAboveFoldCache.push({
+      element: element,
+      aboveFold: aboveFold
+    });
 
     // set clear style back to what it was
     element.style.clear = originalClearStyle;

--- a/lib/phantomjs/core.js
+++ b/lib/phantomjs/core.js
@@ -24,8 +24,8 @@ var criticalCssOptions = {
   ast: args[2],
   width: args[3],
   height: args[4],
-  // always forceInclude '*' selector
-  forceInclude: [{ value: '*' }].concat(JSON.parse(args[5]) || []),
+  // always forceInclude '*', 'html', and 'body' selectors
+  forceInclude: [{ value: '*' }, { value: 'html' }, { value: 'body' }].concat(JSON.parse(args[5]) || []),
   userAgent: args[6],
   renderWaitTime: parseInt(args[7], 10),
   blockJSRequests: args[8],

--- a/src/phantomjs/core.js
+++ b/src/phantomjs/core.js
@@ -149,11 +149,26 @@ function pruneNonCriticalCss (
   // we will replace all instances of these psuedo selectors; hence global flag
   var PSUEDO_SELECTOR_REGEXP = new RegExp(psuedoSelectorsToKeepRegex, 'g')
 
+  // cache whether elements are above fold,
+  // primarily because getBoundingClientRect() can be slow to query,
+  // and some stylesheets have lots of generic selectors (like '.button', '.fa' etc)
+  var isElementAboveFoldCache = []
   var isElementAboveFold = function (element) {
+    // no support for Array.find
+    var matching = isElementAboveFoldCache.filter(c => c.element === element)
+    var cached = matching && matching[0]
+    if (cached) {
+      return cached.aboveFold
+    }
     // temporarily force clear none in order to catch elements that clear previous content themselves and who w/o their styles could show up unstyled in above the fold content (if they rely on f.e. 'clear:both;' to clear some main content)
     var originalClearStyle = element.style.clear || ''
     element.style.clear = 'none'
     var aboveFold = element.getBoundingClientRect().top < h
+    // cache so we dont have to re-query dom for this value
+    isElementAboveFoldCache.push({
+      element: element,
+      aboveFold: aboveFold
+    })
 
     // set clear style back to what it was
     element.style.clear = originalClearStyle

--- a/src/phantomjs/core.js
+++ b/src/phantomjs/core.js
@@ -24,8 +24,10 @@ var criticalCssOptions = {
   ast: args[2],
   width: args[3],
   height: args[4],
-  // always forceInclude '*' selector
-  forceInclude: [{ value: '*' }].concat(JSON.parse(args[5]) || []),
+  // always forceInclude '*', 'html', and 'body' selectors
+  forceInclude: [{ value: '*' }, { value: 'html' }, { value: 'body' }].concat(
+    JSON.parse(args[5]) || []
+  ),
   userAgent: args[6],
   renderWaitTime: parseInt(args[7], 10),
   blockJSRequests: args[8],

--- a/test/core-tests.js
+++ b/test/core-tests.js
@@ -14,7 +14,7 @@ describe('penthouse core tests', function () {
   var page1 = path.join(__dirname, 'static-server', 'page1.html')
 
   // phantomjs takes a while to start up
-  this.timeout(5000)
+  this.timeout(10000)
 
   it('should match exactly the css in the yeoman test', function (done) {
     var yeomanFullCssFilePath = path.join(__dirname, 'static-server', 'yeoman-full.css'),

--- a/test/node-module-tests.js
+++ b/test/node-module-tests.js
@@ -17,7 +17,7 @@ describe('extra tests for penthouse node module', function () {
   var page1cssPath = path.join(__dirname, 'static-server', 'page1.css')
 
   // phantomjs takes a while to start up
-  this.timeout(5000)
+  this.timeout(10000)
 
   // module handles both callback (legacy), and promise
   it('module invocation should return promise', function (done) {


### PR DESCRIPTION
I was looking into a case where Penthouse execution took around 90s, which is way out of the ordinary, and found some really neat perf improvements ✨  - bringing the same case down to 6s execution time (15x faster) 💪. A well linted, slim css file will not be effected much. 

The bottleneck was getBoundingClientRect calls, in particular to elements taking up a large screen estate, like `body` and selectors like `.page-container`. In some cases I saw individually getBoundingClientRect calls taking over 500ms, which quickly piled up in a large css file.

### The improvements
- never query the DOM for `html` and `body` selectors, since they are always "above the fold"
- cache `isAboveFold` computations per element.

### Notes
- given the new cache, penthouse calls will now consume more memory. I haven't seen anything worth worrying about in my tests however, even with really large css files
- in theory, further optimizations could be to avoid sequences of write/read/write DOM operations per element in loops. However such optimizations cannot be made as long as Penthouse manipulates styles on each element, such as for resetting `clear` styles (to ensure it's safe to remove element styles without the element then coming "back" into critical viewport)
- these measurements and optimizations apply to the phantomJS environment. In the future Penthouse might be running in headless chrome (#169) and if so these optimisations would have to be re-evaluated.