### PR TITLE
Specify a branch for pocketjoso/css to fix yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "apartment": "^1.1.1",
-    "css": "https://github.com/pocketjoso/css.git",
+    "css": "https://github.com/pocketjoso/css.git#master",
     "css-mediaquery": "^0.1.2",
     "jsesc": "^1.0.0",
     "os-tmpdir": "^1.0.1",


### PR DESCRIPTION
Otherwise, it triggers the error

```
$ yarn install
yarn install v0.27.5
info No lockfile found.
[1/4] Resolving packages...
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error Refusing to download the git repo {"hostname":"github.com","protocol":"https:","repository":"https://github.com/pocketjoso/css.git"} over HTTPS without a commit hash - possible certificate error?
```