### PR TITLE
Support forceinclude regex flags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,11 @@ function penthouseScriptArgs (options, astFilename) {
         typeof forceIncludeValue === 'object' &&
         forceIncludeValue.constructor.name === 'RegExp'
       ) {
-        return { type: 'RegExp', value: forceIncludeValue.source }
+        return {
+          type: 'RegExp',
+          source: forceIncludeValue.source,
+          flags: forceIncludeValue.flags
+        }
       }
       return { value: forceIncludeValue }
     })

--- a/src/phantomjs/core.js
+++ b/src/phantomjs/core.js
@@ -189,8 +189,9 @@ function pruneNonCriticalCss (
   var matchesForceInclude = function (selector) {
     return forceInclude.some(function (includeSelector) {
       if (includeSelector.type === 'RegExp') {
-        var pattern = new RegExp(includeSelector.value)
-        return pattern.test(selector)
+        const { source, flags } = includeSelector
+        const re = new RegExp(source, flags)
+        return re.test(selector)
       }
       return includeSelector.value === selector
     })

--- a/test/core-tests.js
+++ b/test/core-tests.js
@@ -213,7 +213,7 @@ describe('penthouse core tests', function () {
       forceInclude: [
         '.myLoggedInSelectorRemainsEvenThoughNotFoundOnPage',
         '#box1:hover',
-        /^\.component/
+        /^\.COMPONENT/i // intentionally mismatching case to test regex flags
       ]
     }, function (err, result) {
       try {


### PR DESCRIPTION
They were previously ignored, meaning that you couldn't f.e. ignore case (`/something/i`). Now fixed.