### PR TITLE
Check for node version in postinstall script

### DIFF
--- a/check.js
+++ b/check.js
@@ -1,0 +1,22 @@
+const colors = require('chalk');
+const pkg = require('./package.json');
+
+const version = parseFloat( process.version.substr(1) );
+const minimum = parseFloat( pkg.engines.node.match(/\d+/g).join('.') );
+
+module.exports = function () {
+  if (version >= minimum) {
+    return true;
+  }
+
+	const errorMessage = colors.yellow(`
+
+		⚠️  penthouse requires at least node@${minimum}!
+		You have node@${version}
+
+	`);
+
+  // version not supported && exit
+  process.stdout.write(errorMessage) + '\n';
+  process.exit(1);
+};

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "standard \"src/**/*.js\"",
     "test": "mocha --compilers js:babel-core/register test/core-tests",
     "test-all": "mocha --compilers js:babel-core/register",
+    "postinstall": "node -p 'require(\"./check.js\")()'",
     "precommit": "lint-staged",
     "prepublish": "npm run lint && npm run transpile && cp src/phantomjs/config.json lib/phantomjs/",
     "transpile": "babel -d lib src/"
@@ -36,6 +37,7 @@
   },
   "dependencies": {
     "apartment": "^1.1.1",
+    "chalk": "^2.1.0",
     "css-fork-pocketjoso": "^2.2.1",
     "css-mediaquery": "^0.1.2",
     "jsesc": "^1.0.0",
@@ -70,6 +72,7 @@
     "tool"
   ],
   "files": [
+    "check.js",
     "lib/**/*.js",
     "lib/phantomjs/config.json"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,6 +53,12 @@ ansi-styles@^3.0.0:
   dependencies:
     color-convert "^1.0.0"
 
+ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
@@ -811,6 +817,14 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -863,7 +877,7 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-color-convert@^1.0.0:
+color-convert@^1.0.0, color-convert@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
   dependencies:
@@ -1733,6 +1747,10 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -3297,6 +3315,12 @@ strip-json-comments@~2.0.1:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^4.0.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
+  dependencies:
+    has-flag "^2.0.0"
 
 symbol-observable@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
This closes #175 (added chalk as a dependency)