### PR TITLE
Changes package.json to point to Puppeteer's package instead of repo. Also fixes typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ penthouse({
     userAgent: 'Penthouse Critical Path CSS Generator', // specify which user agent string when loading the page
     renderWaitTime: 100,            // ms; render wait timeout before CSS processing starts (default: 100)
     blockJSRequests: true          // set to false to load (external) JS (default: true)
-    },
     customPageHeaders: {
       'Accept-Encoding': 'identity' // add if getting compression errors like 'Data corrupted'
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "css-fork-pocketjoso": "^2.2.1",
     "css-mediaquery": "^0.1.2",
     "jsesc": "^1.0.0",
-    "puppeteer": "GoogleChrome/puppeteer"
+    "puppeteer": "^0.11.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,9 +2797,9 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-puppeteer@GoogleChrome/puppeteer:
-  version "0.11.0-alpha"
-  resolved "https://codeload.github.com/GoogleChrome/puppeteer/tar.gz/aa58f25bc1c7f8cf72c70c453f036bb873349164"
+puppeteer@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.11.0.tgz#0a2b856f3c2745a5884c6dde9fb44f96663988ed"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"


### PR DESCRIPTION
# Problems
* `README.md` has a small typo in the example (an extra `},`, not needed 😉 ).
* The fact that the project uses `puppeteer` is awesome. However, because it is pointing to Google's github repo it gets the master and does not run the build to be compliant with Node 6, which causes the following error:

![screen shot 2017-09-19 at 17 17 27](https://user-images.githubusercontent.com/1002056/30600015-99127a90-9d5e-11e7-8f51-ed7ad82ecced.png)

# Solutions/Work Done:

* Fixes the typo on the `README.md`'s example.
* Changes the `package.json` to point to the (currently latest) puppeteer's package version instead of its repo. Also changes the `yarn.lock` to point to the correct version. Both steps done via `yarn add puppeteer` as @pocketjoso suggested. 

Note: this is my first PR in this repo, all feedback about contribution procedures (but not only) is more than welcome 👍 