### PR TITLE
Fix bug causing chrome page to not be closed

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -35,8 +35,9 @@ async function pruneNonCriticalCssLauncher ({
 }) {
   let _hasExited = false
   const takeScreenshots = screenshots && screenshots.basePath
-  const screenshotExtension =
-    takeScreenshots && screenshots.type === 'jpeg' ? '.jpg' : '.png'
+  const screenshotExtension = takeScreenshots && screenshots.type === 'jpeg'
+    ? '.jpg'
+    : '.png'
 
   return new Promise(async (resolve, reject) => {
     debuglog('Penthouse core start')
@@ -51,7 +52,7 @@ async function pruneNonCriticalCssLauncher ({
       clearTimeout(killTimeout)
       // page.close will error if page/browser has already been closed;
       // try to avoid
-      if (page && !(error && error.toString().indexOf('Target closed' > -1))) {
+      if (page && !(error && error.toString().indexOf('Target closed') > -1)) {
         // must await here, otherwise will receive errors if closing
         // browser before page is properly closed
         await page.close()

--- a/test/node-module-tests.js
+++ b/test/node-module-tests.js
@@ -101,9 +101,9 @@ describe('extra tests for penthouse node module', function () {
         // NOTE: this test assumes no other chrome processes are running in this environment
         setTimeout(() => {
           chromeProcessesRunning()
-          .then(chromiumStillRunning => {
-            if (chromiumStillRunning) {
-              done(new Error('Chromium seems to not have shut down properly: ' + chromiumStillRunning))
+          .then(({browsers, pages}) => {
+            if (browsers || pages) {
+              done(new Error('Chromium seems to not have shut down properly: ' + {browsers, pages}))
             } else {
               done()
             }
@@ -124,8 +124,8 @@ describe('extra tests for penthouse node module', function () {
       // NOTE: this test assumes no other chrome processes are running in this environment
       setTimeout(() => {
         chromeProcessesRunning()
-        .then(chromiumStillRunning => {
-          if (chromiumStillRunning) {
+        .then(({browsers, pages}) => {
+          if (browsers) {
             done()
           } else {
             done(new Error('Chromium did NOT keep running despite option telling it so'))

--- a/test/node-module-tests.js
+++ b/test/node-module-tests.js
@@ -137,4 +137,29 @@ describe('extra tests for penthouse node module', function () {
       done(err)
     })
   })
+
+  it('should close browser page even if page execution errored, in unstableKeepBrowserAlive mode', function (done) {
+    penthouse.DEBUG = true
+    penthouse({
+      url: 'http://localhost.does.not.exist',
+      css: page1cssPath,
+      unstableKeepBrowserAlive: true
+    })
+    .catch(err => {
+      // NOTE: this test assumes no other chrome processes are running in this environment
+      setTimeout(() => {
+        chromeProcessesRunning()
+        .then(({browsers, pages}) => {
+          // chrome browser opens with an empty page (tab),
+          // which we are just ignoring for now -
+          // did the _extra_ page we opened close, or are we left with 2?
+          if (pages && pages.length > 1) {
+            done(new Error('Chromium seems to not have closed the page we opened, kept nr of pages: ' + pages.length))
+          } else {
+            done()
+          }
+        })
+      }, 1000)
+    })
+  })
 })

--- a/test/util/chromeProcessesRunning.js
+++ b/test/util/chromeProcessesRunning.js
@@ -10,7 +10,7 @@ function grepProcessByPattern (pattern) {
     grep.stdout.on('data', (data) => {
       const result = data.toString()
       if (result.length) {
-        matchingProcesses = result
+        matchingProcesses = result.split('\n').filter(i => !!i)
       }
     })
     grep.on('close', () => {


### PR DESCRIPTION
Pages that had some error f.e. when failed to be opened where never closed, leading to these extra chrome processes hogging extra resources and essentially acting as a memory leak (although outside of the Node process).