### PR TITLE
add keepLargerMediaQueries option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ penthouse({
     url: 'http://google.com',       // can also use file:/// protocol for local files
     cssString: 'body { color; red }', // the original css to extract critcial css from
     // css: 'pathTo/main.css',      // path to original css file on disk
+
     // OPTIONAL params
     width: 1300,                    // viewport width
     height: 900,                    // viewport height
+    keepLargerMediaQueries: false,  // when true, will not filter out larger media queries
     forceInclude: [ // selectors to keep
       '.keepMeEvenIfNotSeenInDom',
       /^\.regexWorksToo/

--- a/src/non-matching-media-query-remover.js
+++ b/src/non-matching-media-query-remover.js
@@ -1,9 +1,12 @@
 'use strict'
 
 var cssMediaQuery = require('css-mediaquery')
-// only filter out: print, min-width > width and min-height > height
 
-function _isMatchingMediaQuery (rule, matchConfig) {
+// only filters out:
+//  - @print
+//  - min-width > width OR min-height > height
+// and the latter only if !keepLargerMediaQueries (which is the default)
+function _isMatchingMediaQuery (rule, matchConfig, keepLargerMediaQueries) {
   if (rule.type !== 'media') {
     // ignore (keep) all non media query rules
     return true
@@ -19,6 +22,9 @@ function _isMatchingMediaQuery (rule, matchConfig) {
   var keep = mediaAST.some(function (mq) {
     if (mq.type === 'print') {
       return false
+    }
+    if (keepLargerMediaQueries) {
+      return true
     }
     // f.e. @media all {}
     // go for false positives over false negatives,
@@ -40,14 +46,19 @@ function _isMatchingMediaQuery (rule, matchConfig) {
   return keep
 }
 
-function nonMatchingMediaQueryRemover (rules, width, height) {
+function nonMatchingMediaQueryRemover (
+  rules,
+  width,
+  height,
+  keepLargerMediaQueries
+) {
   var matchConfig = {
     type: 'screen',
     width: width + 'px',
     height: height + 'px'
   }
   return rules.filter(function (rule) {
-    return _isMatchingMediaQuery(rule, matchConfig)
+    return _isMatchingMediaQuery(rule, matchConfig, keepLargerMediaQueries)
   })
 }
 

--- a/test/post-formatting-tests.js
+++ b/test/post-formatting-tests.js
@@ -62,6 +62,16 @@ describe('penthouse post formatting tests', function () {
     done()
   })
 
+  it('should keep larger media queries when keepLargerMediaQueries is true', function (done) {
+    const originalCss = read(path.join(__dirname, 'static-server', 'non-matching-mq--remove.css'), 'utf8')
+
+    const smallViewportRules = nonMatchingMediaQueryRemover(css.parse(originalCss).stylesheet.rules, 600, 600, true)
+    // a bit fragile: the file currently contains 6 rules:
+    // 1 print (remove), and 5 larger media queries (keep, with this setting)
+    smallViewportRules.should.have.length(5)
+    done()
+  })
+
   it('should only keep @keyframe rules used in critical css', function (done) {
     const originalCss = read(path.join(__dirname, 'static-server', 'unused-keyframes.css'), 'utf8')
     const expextedCss = read(path.join(__dirname, 'static-server', 'unused-keyframes--expected.css'), 'utf8')


### PR DESCRIPTION
given that Penthouse works very well to generate only one critical css file
per page (as opposed to different ones for different viewport sizes),
and that this is what I recommend - it makes sense to allow to keep larger
media queries so truly make the critical css work for all sizes.

`keepLargerMediaQueries enables this behavior`. The default value is set to `false`,
to be backwards compatible.