### PR TITLE
Support passing puppeteer browser in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ penthouse({
       // type: 'jpeg', // jpeg or png, png default
       // quality: 20 // only applies for jpeg type
       // -> these settings will produce homepage-before.jpg and homepage-after.jpg
+    },
+    puppeteer: {
+      getBrowser: undefined,        // A function that resolves with a puppeteer browser to use instead of launching a new browser session
     }
 })
 .then(criticalCss => {

--- a/src/index.js
+++ b/src/index.js
@@ -266,7 +266,7 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
         if (_browserLaunchPromise) {
           // in this case the browser is already restarting
           await _browserLaunchPromise
-        } else {
+        } else if (!(options.puppeteer && options.puppeteer.getBrowser)) {
           console.log('restarting chrome after crash')
           browser = null
           await launchBrowserIfNeeded({}, debuglog)

--- a/src/index.js
+++ b/src/index.js
@@ -35,12 +35,12 @@ let _browserLaunchPromise = null
 // browser.pages is not implemented, so need to count myself to not close browser
 // until all pages used by penthouse are closed (i.e. individual calls are done)
 let _browserPagesOpen = 0
-const launchBrowserIfNeeded = async function (options, debuglog) {
+const launchBrowserIfNeeded = async function ({ getBrowser }, debuglog) {
   if (browser) {
     return
   }
-  if (options.puppeteer && typeof options.puppeteer.getBrowser === 'function') {
-    _browserLaunchPromise = Promise.resolve(options.puppeteer.getBrowser())
+  if (getBrowser && typeof getBrowser === 'function') {
+    _browserLaunchPromise = Promise.resolve(getBrowser())
   }
   if (!_browserLaunchPromise) {
     debuglog('no browser instance, launching new browser..')
@@ -269,7 +269,7 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
         } else {
           console.log('restarting chrome after crash')
           browser = null
-          await launchBrowserIfNeeded(options, debuglog)
+          await launchBrowserIfNeeded({}, debuglog)
         }
         // retry
         resolve(
@@ -373,7 +373,12 @@ const m = (module.exports = function (options, callback) {
       return
     }
 
-    await launchBrowserIfNeeded(options, debuglog)
+    await launchBrowserIfNeeded(
+      {
+        getBrowser: options.puppeteer && options.puppeteer.getBrowser
+      },
+      debuglog
+    )
     try {
       const ast = await astFromCss(options, logging)
       const criticalCss = await generateCriticalCssWrapped(


### PR DESCRIPTION
Checking if `puppeteer.getBrowser` function is passed in props to use it for launching browser instead, closes #198.