### PR TITLE
 Use debugjs for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ The Penthouse Node module can also be used in Gulp.
 
 ## Troubleshooting
 
+
+### Enable debug logging
+Logging is done via the [`debug`](https://github.com/visionmedia/debug) module under the `penthouse` namespace. You can view more about the logging on their [documentation](https://github.com/visionmedia/debug#usage).
+
+```sh
+# Basic verbose logging for all components
+env DEBUG="penthouse,penthouse:*" node script.js
+```
+
 ### Not working on Linux
 Install missing dependencies to get the headless Chrome to run:
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "apartment": "^1.1.1",
     "css-fork-pocketjoso": "^2.2.1",
     "css-mediaquery": "^0.1.2",
+    "debug": "^3.1.0",
     "jsesc": "^1.0.0",
     "puppeteer": "^0.13.0"
   },

--- a/src/core.js
+++ b/src/core.js
@@ -1,6 +1,9 @@
+import debug from 'debug'
 import pruneNonCriticalCss from './browser-sandbox/pruneNonCriticalCss'
 import replacePageCss from './browser-sandbox/replacePageCss'
 import postformatting from './postformatting/'
+
+const debuglog = debug('penthouse:core')
 
 function blockinterceptedRequests (interceptedRequest) {
   const isJsRequest = /\.js(\?.*)?$/.test(interceptedRequest.url)
@@ -31,8 +34,7 @@ async function pruneNonCriticalCssLauncher ({
   customPageHeaders,
   screenshots,
   propertiesToRemove,
-  maxEmbeddedBase64Length,
-  debuglog
+  maxEmbeddedBase64Length
 }) {
   let _hasExited = false
   const takeScreenshots = screenshots && screenshots.basePath
@@ -80,6 +82,7 @@ async function pruneNonCriticalCssLauncher ({
 
       if (customPageHeaders) {
         try {
+          debuglog('set custom headers')
           await page.setExtraHTTPHeaders(customPageHeaders)
         } catch (e) {
           debuglog('failed setting extra http headers: ' + e)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import cssAstFormatter from 'css-fork-pocketjoso'
 import puppeteer from 'puppeteer'
+import debug from 'debug'
 
 import generateCriticalCss from './core'
 import normalizeCss from './normalize-css'
@@ -169,7 +170,7 @@ const astFromCss = async function astFromCss (options, { debuglog, stdErr }) {
 const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
   options,
   ast,
-  { debuglog, stdErr, START_TIME, forceTryRestartBrowser }
+  { debuglog, stdErr, forceTryRestartBrowser }
 ) {
   const width = parseInt(options.width || DEFAULT_VIEWPORT_WIDTH, 10)
   const height = parseInt(options.height || DEFAULT_VIEWPORT_HEIGHT, 10)
@@ -276,7 +277,6 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
           generateCriticalCssWrapped(options, ast, {
             debuglog,
             stdErr,
-            START_TIME,
             forceTryRestartBrowser
           })
         )
@@ -305,24 +305,18 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
 const m = (module.exports = function (options, callback) {
   // init logging and debug output
   normalizeCss.DEBUG = m.DEBUG
-  const START_TIME = Date.now()
+  const debuglogger = debug('penthouse')
   const debuglog = function (msg, isError) {
-    if (m.DEBUG) {
-      const errMsg =
-        'time: ' +
-        (Date.now() - START_TIME) +
-        ' | ' +
-        (isError ? 'ERR: ' : '') +
-        msg
+    if (isError) {
       console.error(errMsg)
       return errMsg
     }
-    return ''
+    debuglogger(msg)
   }
+
   const logging = {
     debuglog,
-    stdErr: '',
-    START_TIME
+    stdErr: ''
   }
 
   process.on('exit', exitHandler)

--- a/src/index.js
+++ b/src/index.js
@@ -302,14 +302,13 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
   })
 }
 
-const m = (module.exports = function (options, callback) {
+module.exports = function (options, callback) {
   // init logging and debug output
-  normalizeCss.DEBUG = m.DEBUG
   const debuglogger = debug('penthouse')
   const debuglog = function (msg, isError) {
     if (isError) {
-      console.error(errMsg)
-      return errMsg
+      console.error(msg)
+      return msg
     }
     debuglogger(msg)
   }
@@ -385,4 +384,4 @@ const m = (module.exports = function (options, callback) {
       cleanupAndExit({ error: err })
     }
   })
-})
+}

--- a/src/normalize-css.js
+++ b/src/normalize-css.js
@@ -1,6 +1,9 @@
 import jsesc from 'jsesc'
+import debug from 'debug'
 
 import normalizeCss from './browser-sandbox/normalizeCss'
+
+const debuglog = debug('penthouse:normalize-css')
 
 function unEscapeCss (css) {
   return css.replace(/(['"])\\\\/g, `$1\\`)
@@ -40,17 +43,17 @@ function escapeHexRefences (css) {
   )
 }
 
-async function normalizeCssLauncher ({ browser, css, debuglog }) {
+async function normalizeCssLauncher ({ browser, css }) {
   debuglog('normalizeCss: ' + css.length)
 
   // escape hex referenced unicode chars in content:'' declarations,
   // i.e. \f091'
   // so they stay in the same format
   const escapedCss = escapeHexRefences(css)
-  debuglog('normalizeCss: escaped hex')
+  debuglog('escaped hex')
 
   const page = await browser.newPage()
-  debuglog('normalizeCss: new page opened in browser')
+  debuglog('new page opened in browser')
 
   page.on('console', msg => {
     // pass through log messages


### PR DESCRIPTION
Uses debugjs for debugging, the same as puppeteer is using, this allows
for easier debugging, in a way that's similar with puppeteer. Also document this change.

Here is a preview from powershell:

![image](https://user-images.githubusercontent.com/453018/33426275-9134bebe-d5c1-11e7-8091-f3bf457ac330.png)


Note:

Example could also be `env DEBUG="penthouse*" node script.js` but I feel the other is easier to understand. We could also scope everything in `index.js` to `penthouse:index` then `env DEBUG="penthouse:*" node script.js` would work fine.
