### PR TITLE
All postformatting done on ast

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import csstree from 'css-tree'
 import debug from 'debug'
 import pruneNonCriticalCss from './browser-sandbox/pruneNonCriticalCss'
 import replacePageCss from './browser-sandbox/replacePageCss'
@@ -180,12 +181,19 @@ async function pruneNonCriticalCssLauncher ({
       })
       debuglog('generateCriticalCss done, now postformat')
 
-      const formattedCss = postformatting({
+      const formattedAstRules = postformatting({
         astRulesCritical,
         propertiesToRemove,
         maxEmbeddedBase64Length
       })
       debuglog('postformatting done')
+
+      const finalAst = csstree.fromPlainObject({
+        type: 'StyleSheet',
+        children: formattedAstRules
+      })
+      const formattedCss = csstree.translate(finalAst)
+      debuglog('stringify from ast')
 
       if (takeScreenshots) {
         debuglog('inline critical styles for after screenshot')

--- a/src/postformatting/index.js
+++ b/src/postformatting/index.js
@@ -1,4 +1,3 @@
-import csstree from 'css-tree'
 import debug from 'debug'
 
 import embeddedbase64Remover from './embedded-base64-remover'
@@ -15,33 +14,26 @@ export default function postformatting ({
 }) {
   debuglog('start')
 
-  let filteredCriticalRules = unusedKeyframeRemover(astRulesCritical)
+  let formattedCriticalRules = unusedKeyframeRemover(astRulesCritical)
   debuglog('unusedKeyframeRemover')
 
   // remove unused @fontface rules
-  filteredCriticalRules = ffRemover(filteredCriticalRules)
+  formattedCriticalRules = ffRemover(formattedCriticalRules)
   debuglog('ffRemover')
 
   // remove data-uris that are too long
-  filteredCriticalRules = embeddedbase64Remover(
-    filteredCriticalRules,
+  formattedCriticalRules = embeddedbase64Remover(
+    formattedCriticalRules,
     maxEmbeddedBase64Length
   )
   debuglog('embeddedbase64Remover')
 
   // remove irrelevant css properties via rule walking
-  filteredCriticalRules = unwantedPropertiesRemover(
-    filteredCriticalRules,
+  formattedCriticalRules = unwantedPropertiesRemover(
+    formattedCriticalRules,
     propertiesToRemove
   )
   debuglog('propertiesToRemove')
 
-  const finalAst = csstree.fromPlainObject({
-    type: 'StyleSheet',
-    children: filteredCriticalRules
-  })
-  let finalCss = csstree.translate(finalAst)
-  debuglog('stringify from ast')
-
-  return finalCss
+  return formattedCriticalRules
 }

--- a/src/postformatting/index.js
+++ b/src/postformatting/index.js
@@ -18,6 +18,10 @@ export default function postformatting ({
   let filteredCriticalRules = unusedKeyframeRemover(astRulesCritical)
   debuglog('unusedKeyframeRemover')
 
+  // remove unused @fontface rules
+  filteredCriticalRules = ffRemover(filteredCriticalRules)
+  debuglog('ffRemover')
+
   // remove data-uris that are too long
   filteredCriticalRules = embeddedbase64Remover(
     filteredCriticalRules,
@@ -38,10 +42,6 @@ export default function postformatting ({
   })
   let finalCss = csstree.translate(finalAst)
   debuglog('stringify from ast')
-
-  // remove unused @fontface rules
-  finalCss = ffRemover(finalCss)
-  debuglog('ffRemover')
 
   return finalCss
 }

--- a/src/postformatting/unused-fontface-remover.js
+++ b/src/postformatting/unused-fontface-remover.js
@@ -1,66 +1,51 @@
-/*
-module for removing unused fontface rules
-*/
+import debug from 'debug'
+const debuglog = debug('penthouse:postformatting:unused-font-face-remover')
 
-'use strict'
-
-// extract full @font-face rules
-const fontFaceRegex = /(@font-face[ \s\S]*?\{([\s\S]*?)\})/gm
-
-function unusedFontfaceRemover (css) {
-  const toDeleteSections = []
-
-  let ff = null
-
-  while ((ff = fontFaceRegex.exec(css)) !== null) {
-    // grab the font name declared in the @font-face rule
-    // (can still be in quotes, f.e. 'Lato Web'
-    const t = /font-family[^:]*?:[ ]*([^;]*)/.exec(ff[1])
-    if (!t || typeof t[1] === 'undefined') {
-      continue // no font-family in @fontface rule!
-    }
-
-    // rm quotes
-    const fontName = t[1].replace(/['"]/gm, '')
-
-    // does this fontname appear as a font-family or font (shorthand) value?
-    const fontNameRegex = new RegExp(
-      '([^{}]*?){[^}]*?font(-family)?[^:}]*?:[^;}]*' + fontName + '[^,;]*[,;]',
-      'gmi'
-    )
-
-    let fontFound = false
-    let m = null
-
-    while ((m = fontNameRegex.exec(css)) !== null) {
-      if (m[1].indexOf('@font-face') === -1) {
-        // log('FOUND, keep rule')
-        fontFound = true
-        break
-      }
-    }
-    if (!fontFound) {
-      // NOT FOUND, rm!
-
-      // can't remove rule here as it will screw up ongoing while (exec ...) loop.
-      // instead: save indices and delete AFTER for loop
-      const closeRuleIndex = css.indexOf('}', ff.index)
-      // unshift - add to beginning of array - we need to remove rules in reverse order,
-      // otherwise indeces will become incorrect again.
-      toDeleteSections.unshift({
-        start: ff.index,
-        end: closeRuleIndex + 1
+function getAllFontNameValues (rules) {
+  let fontNameValues = []
+  function handleRule (rule) {
+    if (rule.type === 'Rule') {
+      rule.block.children.forEach(({ property, value }) => {
+        if (property === 'font-family' || property === 'font') {
+          fontNameValues.push(value.value)
+        }
       })
+    } else if (rule.type === 'Atrule' && rule.name === 'media') {
+      rule.block.children.forEach(handleRule)
     }
   }
-  // now delete the @fontface rules we registed as having no matches in the css
-  for (let i = 0; i < toDeleteSections.length; i++) {
-    const start = toDeleteSections[i].start
-    const end = toDeleteSections[i].end
-    css = css.substring(0, start) + css.substring(end)
+  rules.forEach(handleRule)
+  return fontNameValues
+}
+
+function unusedFontfaceRemover (rules) {
+  debuglog('getAllFontNameValues')
+  const fontNameValues = getAllFontNameValues(rules)
+  debuglog('getAllFontNameValues AFTER')
+
+  function filterUnusedFontFaceRule (rule) {
+    if (!(rule.type === 'Atrule' && rule.name === 'font-face')) {
+      return true
+    }
+    // was this @font-face used?
+    return rule.block.children.some(({ property, value }) => {
+      let toKeep = false
+      let font
+      if (property === 'font-family') {
+        font = value.value
+      }
+      if (font) {
+        toKeep = fontNameValues.some(value => value.indexOf(font) !== -1)
+        if (!toKeep) {
+          debuglog('drop unused font-face rule: ' + font)
+        }
+      }
+      return toKeep
+    })
   }
 
-  return css
+  // remove all unused font-face declarations
+  return rules.filter(filterUnusedFontFaceRule)
 }
 
 if (typeof module !== 'undefined') {

--- a/src/postformatting/unused-fontface-remover.js
+++ b/src/postformatting/unused-fontface-remover.js
@@ -20,6 +20,10 @@ function getAllFontNameValues (rules) {
 
 function unusedFontfaceRemover (rules) {
   debuglog('getAllFontNameValues')
+  // NOTE: we grabp the full declaration everywhere a font name is used,
+  // and just do a simple index of on these lines to see if each @font-face
+  // is used anywhere. Could in theory yield false positives, but is quite unlikely,
+  // unless people use css keywoards in their custom font names.
   const fontNameValues = getAllFontNameValues(rules)
   debuglog('getAllFontNameValues AFTER')
 
@@ -33,6 +37,10 @@ function unusedFontfaceRemover (rules) {
       let font
       if (property === 'font-family') {
         font = value.value
+          // replace quoute mark to ensure we match inside font declaration,
+          // in case appears without them there
+          .replace(/^['"]/, '')
+          .replace(/['"]$/, '')
       }
       if (font) {
         toKeep = fontNameValues.some(value => value.indexOf(font) !== -1)

--- a/test/post-formatting-tests.js
+++ b/test/post-formatting-tests.js
@@ -70,21 +70,23 @@ describe('penthouse post formatting tests', function () {
   })
 
   it('should remove @fontface rule, because it is not used', function (done) {
-    var fontFaceRemoveCssFilePath = path.join(__dirname, 'static-server', 'fontface--remove.css'),
-      fontFaceRemoveExpectedCssFilePath = path.join(__dirname, 'static-server', 'fontface--remove--expected.css'),
-      fontFaceRemoveCss = read(fontFaceRemoveCssFilePath).toString(),
-      fontFaceRemoveExpectedCss = read(fontFaceRemoveExpectedCssFilePath).toString()
+    var fontFaceRemoveCssFilePath = path.join(__dirname, 'static-server', 'fontface--remove.css')
+    var fontFaceRemoveExpectedCssFilePath = path.join(__dirname, 'static-server', 'fontface--remove--expected.css')
+    var fontFaceRemoveCss = read(fontFaceRemoveCssFilePath).toString()
+    var fontFaceRemoveExpectedCss = read(fontFaceRemoveExpectedCssFilePath).toString()
 
-    var result = ffRemover(fontFaceRemoveCss)
+    const ast = normaliseCssAst(fontFaceRemoveCss)
+    const astRules = csstree.toPlainObject(ast).children
+    var resultRules = ffRemover(astRules)
+    const resultAst = csstree.fromPlainObject({
+      type: 'StyleSheet',
+      loc: null,
+      children: resultRules
+    })
 
-    try {
-      var resultAst = normaliseCssAst(result)
-      var expectedAst = normaliseCssAst(fontFaceRemoveExpectedCss)
-      resultAst.should.eql(expectedAst)
-      done()
-    } catch (ex) {
-      done(ex)
-    }
+    const expectedAst = normaliseCssAst(fontFaceRemoveExpectedCss)
+    resultAst.should.eql(expectedAst)
+    done()
   })
 
   it('should only keep @keyframe rules used in critical css', function (done) {

--- a/test/static-server/fontface--remove--expected.css
+++ b/test/static-server/fontface--remove--expected.css
@@ -1,6 +1,8 @@
 html {
-	font-family: Arial;
+	font-family: Arial,Verdana;
+}
+body {
+  font: 16px 'museo-500';
 }
 
 @font-face{font-family:museo-500;font-style:normal;src:url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot);src:local('museo-500'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot) format('embedded-opentype'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.woff) format('woff')}
-body{font-family:museo-500!important;}

--- a/test/static-server/fontface--remove--expected.css
+++ b/test/static-server/fontface--remove--expected.css
@@ -2,7 +2,14 @@ html {
 	font-family: Arial,Verdana;
 }
 body {
-  font: 16px 'museo-500';
+  font: normal normal normal 14px/1 FontAwesome;
 }
 
-@font-face{font-family:museo-500;font-style:normal;src:url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot);src:local('museo-500'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot) format('embedded-opentype'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.woff) format('woff')}
+@font-face {
+	/*important: using quoute marks here, but not in usage above, to test that we still match and keep the font-face */
+	font-family: "FontAwesome";
+  src: url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.eot?v=4.7.0);
+  src: url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.eot?#iefix&v=4.7.0) format('embedded-opentype'), url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.woff2?v=4.7.0) format('woff2'), url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.woff?v=4.7.0) format('woff'), url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.ttf?v=4.7.0) format('truetype'), url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular) format('svg');
+  font-weight: 400;
+  font-style: normal
+}

--- a/test/static-server/fontface--remove.css
+++ b/test/static-server/fontface--remove.css
@@ -8,8 +8,15 @@ html {
 	font-family: Arial,Verdana;
 }
 body {
-  font: 16px 'museo-500';
+  font: normal normal normal 14px/1 FontAwesome;
 }
 
-@font-face{font-family:museo-500;font-style:normal;src:url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot);src:local('museo-500'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot) format('embedded-opentype'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.woff) format('woff')}
+@font-face {
+  /*important: using quoute marks here, but not in usage above, to test that we still match and keep the font-face */
+  font-family: "FontAwesome";
+  src: url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.eot?v=4.7.0);
+  src: url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.eot?#iefix&v=4.7.0) format('embedded-opentype'), url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.woff2?v=4.7.0) format('woff2'), url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.woff?v=4.7.0) format('woff'), url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.ttf?v=4.7.0) format('truetype'), url(https://cigarstar.ca/wp-content/themes/claue/assets/vendors/font-awesome/css/../fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular) format('svg');
+  font-weight: 400;
+  font-style: normal
+}
 @font-face{font-family:mikado-bold;font-style:normal;src:url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot);src:local('mikado-bold'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot) format('embedded-opentype'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.woff) format('woff')}

--- a/test/static-server/fontface--remove.css
+++ b/test/static-server/fontface--remove.css
@@ -5,8 +5,11 @@
     src: url('fonts/Lato-Regular.eot');
 }
 html {
-	font-family: Arial;
+	font-family: Arial,Verdana;
+}
+body {
+  font: 16px 'museo-500';
 }
 
 @font-face{font-family:museo-500;font-style:normal;src:url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot);src:local('museo-500'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot) format('embedded-opentype'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.woff) format('woff')}
-@font-face{font-family:mikado-bold;font-style:normal;src:url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot);src:local('mikado-bold'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot) format('embedded-opentype'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.woff) format('woff')}body{font-family:museo-500!important;}
+@font-face{font-family:mikado-bold;font-style:normal;src:url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot);src:local('mikado-bold'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.eot) format('embedded-opentype'),url(http://21339-presscdn.pagely.netdna-cdn.com/wp-content/uploads/useanyfont/160815015629Mikado-Bold.woff) format('woff')}


### PR DESCRIPTION
improves the rest of the postformatting so that none of it operates on a css string, but instead always on the ast format - in my preliminary tests that should be faster. It could be made even faster by doing all the transformations in a single iteration, instead of once per postformatting process, but that's for the future (if it's even worth it, would have to do some more specific measurements first; normally now these operations are very fast..)