### PR TITLE
Fixed pruneNonCriticalCssLauncher call

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -47,13 +47,13 @@ async function pruneNonCriticalCssLauncher ({
   customPageHeaders,
   screenshots,
   propertiesToRemove,
-  maxEmbeddedBase64Length
+  maxEmbeddedBase64Length,
+  debuglog
 }) {
   let _hasExited = false
   const takeScreenshots = screenshots && screenshots.basePath
-  const screenshotExtension = takeScreenshots && screenshots.type === 'jpeg'
-    ? '.jpg'
-    : '.png'
+  const screenshotExtension =
+    takeScreenshots && screenshots.type === 'jpeg' ? '.jpg' : '.png'
 
   return new Promise(async (resolve, reject) => {
     debuglog('Penthouse core start')


### PR DESCRIPTION
It seems that `pruneNonCriticalCssLauncher` does not accept the `debuglog` parameter passed to it. This PR fixes it.