### PR TITLE
support puppeteer 1.x API

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -53,7 +53,11 @@ async function loadPage (page, url, timeout, pageLoadSkipTimeout) {
 }
 
 async function blockJsRequests (page) {
-  await page.setRequestInterceptionEnabled(true)
+  if (typeof page.setRequestInterceptionEnabled === 'function') { // backwards compatibility with puppeteer < 1.x
+    await page.setRequestInterceptionEnabled(true)
+  } else {
+    await page.setRequestInterception(true)
+  }
   page.on('request', blockinterceptedRequests)
 }
 


### PR DESCRIPTION
puppeteer API has changed. This PR keeps backwards compatilbility, but also allows newer puppeteers to work.