### PR TITLE
improve parallelization by minimizing await usage

### DIFF
--- a/src/browser-sandbox/pruneNonCriticalSelectors.js
+++ b/src/browser-sandbox/pruneNonCriticalSelectors.js
@@ -65,11 +65,11 @@ export default function pruneNonCriticalSelectors ({
   }
 
   function filterSelectors (selectors) {
-    console.log('debug: filterSelectors BEFORE')
+    console.log('debug: filterSelectors START')
 
     selectors = selectors.filter(isSelectorCritical)
 
-    console.log('debug: filterSelectors AFTER')
+    console.log('debug: filterSelectors DONE')
     return selectors
   }
 

--- a/src/core.js
+++ b/src/core.js
@@ -299,7 +299,12 @@ async function pruneNonCriticalCssLauncher ({
     })
 
     // -> [BLOCK FOR] page load
-    await loadPagePromise
+    try {
+      await loadPagePromise
+    } catch (e) {
+      cleanupAndExit({ error: e })
+      return
+    }
     if (!page) {
       // in case we timed out
       debuglog('page load TIMED OUT')

--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,7 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
           _browserPagesOpen
       )
       if (!forceTryRestartBrowser && !await browserIsRunning()) {
-        console.error(
+        debuglog(
           'Chromium unexpecedly not opened - crashed? ' +
             '\n_browserPagesOpen: ' +
             (_browserPagesOpen + 1) +
@@ -226,7 +226,6 @@ module.exports = function (options, callback) {
   process.on('SIGINT', exitHandler)
 
   return new Promise(async (resolve, reject) => {
-    // still supporting legacy callback way of calling Penthouse
     const cleanupAndExit = ({ returnValue, error = null }) => {
       if (browser && !options.unstableKeepBrowserAlive) {
         if (_browserPagesOpen > 0) {
@@ -241,6 +240,7 @@ module.exports = function (options, callback) {
         }
       }
 
+      // still supporting legacy callback way of calling Penthouse
       if (callback) {
         callback(error, returnValue)
         return


### PR DESCRIPTION
mostly has an impact when taking before/after screenshots, and when the page load is not being the bottle neck. In my production tests the latter is most often the bottle neck however, so hence why this code is better in theory, in practice it does not make much of a difference. I think it is slightly cleaner though.