### PR TITLE
puppeteer@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "css-tree": "1.0.0-alpha.27",
     "debug": "^3.1.0",
     "jsesc": "^1.0.0",
-    "puppeteer": "0.12"
+    "puppeteer": "1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/core.js
+++ b/src/core.js
@@ -54,7 +54,7 @@ async function loadPage (page, url, timeout, pageLoadSkipTimeout) {
 
 function setupBlockJsRequests (page) {
   page.on('request', blockinterceptedRequests)
-  return page.setRequestInterceptionEnabled(true)
+  return page.setRequestInterception(true)
 }
 
 async function astFromCss ({ cssString, strict }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,9 +3872,9 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
-puppeteer@0.12:
-  version "0.12.0"
-  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-0.12.0.tgz#9c421930851594dfdd479d07646666a74ced7719"
+puppeteer@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-1.0.0.tgz#20f3bb6ad6c6778b4d1fb750e808a29fec0a88a4"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"


### PR DESCRIPTION
cannot go to latest version (1.1.1 at time of writing this)
because it reintroduces the `file://` protocol bug that 1.0.0 fixes:

https://github.com/GoogleChrome/puppeteer/issues/1506#issuecomment-371227988