### PR TITLE
Do not recreate browser instance if getBrowser options passed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,12 @@ const launchBrowserIfNeeded = async function ({ getBrowser }) {
   if (browser) {
     return
   }
-  if (getBrowser && typeof getBrowser === 'function') {
-    _browserLaunchPromise = Promise.resolve(getBrowser())
+  if (
+    getBrowser &&
+    typeof getBrowser === 'function' &&
+    !_browserLaunchPromise
+  ) {
+    _browserLaunchPromise = getBrowser()
   }
   if (!_browserLaunchPromise) {
     debuglog('no browser instance, launching new browser..')


### PR DESCRIPTION
Without this check, several browser instances are created. It leads to the process hanging.