### PR TITLE
Keep rules with grid-area property

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-perf": "jest  --runInBand test/run-sequential/perf.test.js",
     "test-extra": "jest --runInBand test/run-sequential/node-module.test.js",
     "precommit": "lint-staged",
-    "prepublish": "npm run lint && npm run transpile",
+    "prepare": "npm run lint && npm run transpile",
     "transpile": "babel -d lib src/"
   },
   "lint-staged": {

--- a/src/core.js
+++ b/src/core.js
@@ -1,7 +1,6 @@
 import csstree from 'css-tree'
 import debug from 'debug'
-import pruneNonCriticalSelectors
-  from './browser-sandbox/pruneNonCriticalSelectors'
+import pruneNonCriticalSelectors from './browser-sandbox/pruneNonCriticalSelectors'
 import replacePageCss from './browser-sandbox/replacePageCss'
 import cleanupAst from './postformatting'
 import buildSelectorProfile from './selectors-profile'
@@ -203,9 +202,8 @@ async function pruneNonCriticalCssLauncher ({
   const getHasExited = () => _hasExited
 
   const takeScreenshots = screenshots && screenshots.basePath
-  const screenshotExtension = takeScreenshots && screenshots.type === 'jpeg'
-    ? '.jpg'
-    : '.png'
+  const screenshotExtension =
+    takeScreenshots && screenshots.type === 'jpeg' ? '.jpg' : '.png'
 
   return new Promise(async (resolve, reject) => {
     debuglog('Penthouse core start')

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,15 @@ const DEFAULT_PROPERTIES_TO_REMOVE = [
   '(-webkit-)?tap-highlight-color',
   '(.*)user-select'
 ]
+const DEFAULT_PUPPETEER_LAUNCH_ARGS = [
+  '--disable-setuid-sandbox',
+  '--no-sandbox',
+  '--ignore-certificate-errors'
+  // better for Docker:
+  // https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#tips
+  // (however caused memory leaks in Penthouse when testing in Ubuntu, hence disabled)
+  // '--disable-dev-shm-usage'
+]
 
 function exitHandler () {
   if (browser && browser.close) {
@@ -51,14 +60,7 @@ const launchBrowserIfNeeded = async function ({ getBrowser }) {
     _browserLaunchPromise = puppeteer
       .launch({
         ignoreHTTPSErrors: true,
-        args: [
-          '--disable-setuid-sandbox',
-          '--no-sandbox',
-          '--ignore-certificate-errors',
-          // better for Docker:
-          // https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#tips
-          '--disable-dev-shm-usage'
-        ]
+        args: DEFAULT_PUPPETEER_LAUNCH_ARGS
       })
       .then(browser => {
         debuglog('new browser launched')

--- a/src/non-matching-media-query-remover.js
+++ b/src/non-matching-media-query-remover.js
@@ -37,7 +37,9 @@ function _isMatchingMediaQuery (mediaQuery, matchConfig) {
     }
     return mq.expressions.some(function ({ modifier, feature, value }) {
       if (modifier === 'min') {
-        const constructedQuery = `${isInverse ? 'not ' : ''}(min-${feature}: ${value})`
+        const constructedQuery = `${
+          isInverse ? 'not ' : ''
+        }(min-${feature}: ${value})`
         return cssMediaQuery.match(constructedQuery, matchConfig)
       } else {
         return true

--- a/src/postformatting/embedded-base64-remover.js
+++ b/src/postformatting/embedded-base64-remover.js
@@ -29,7 +29,9 @@ export default function embeddedbase64Remover (ast, maxEmbeddedBase64Length) {
         const value = csstree.generate(declaration.value)
         debuglog(
           'DROP: ' +
-            `${declaration.property}: ${value.slice(0, 50)}..., (${value.length} chars)`
+            `${declaration.property}: ${value.slice(0, 50)}..., (${
+              value.length
+            } chars)`
         )
         list.remove(item)
       }

--- a/src/selectors-profile.js
+++ b/src/selectors-profile.js
@@ -30,6 +30,10 @@ function matchesForceInclude (selector, forceInclude) {
   })
 }
 
+// returns:
+// true, if selector should be force kept
+// false, if selector should be force removed
+// otherwise the selector string to look for in the critical viewport
 function normalizeSelector (selectorNode, forceInclude) {
   const selector = csstree.generate(selectorNode)
   // some selectors can't be matched on page.
@@ -94,6 +98,17 @@ export default async function buildSelectorProfile (ast, forceInclude) {
       if (rule.prelude.type !== 'SelectorList') {
         return
       }
+
+      const addedRule = rule.block.children.some(declarationNode => {
+        if (declarationNode.property === 'grid-area') {
+          const ruleSelectorList = csstree.generate(rule.prelude)
+          debuglog('rule contains grid-area, keeping: ', ruleSelectorList)
+          selectors.add(ruleSelectorList)
+          selectorNodeMap.set(rule.prelude, ruleSelectorList)
+          return true
+        }
+      })
+      if (addedRule) return
 
       // collect selectors and build a map
       rule.prelude.children.each(selectorNode => {


### PR DESCRIPTION
if a grid parent using grid-template-areas is critical (f.e. the body), thus appearing in the critical css, direct children who are supposed to be placed correctly via grid-area (f.e. as a page footer) can appear incorrectly in the critical viewport if they are not also included. This change essentially force includes them.

Fixes cases where the critical css produced incorrect results.

Ths will make critical css files larger, in vain for most users, and it takes some time to make these extra checks.

I'm currently testing this change to determine the exact extent of the increase in time and size. If too bad, I will consider an alternative solution.

-------

This PR also reverts a change to include `--disable-dev-shm-usage` launch flag to puppeteer, which [is recommended for Docker](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#tips) - however I found that it caused memory leaks, causing crashes, when testing on Ubuntu servers. Users can always [manually set this flag](https://github.com/pocketjoso/penthouse/blob/master/examples/custom-browser.js).