### PR TITLE
Page unloaded explicit handling

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -8,7 +8,7 @@ import nonMatchingMediaQueryRemover from './non-matching-media-query-remover'
 
 const debuglog = debug('penthouse:core')
 
-const PAGE_UNLOADED_DURING_EXECUTION_ERROR_MESSAGE =
+export const PAGE_UNLOADED_DURING_EXECUTION_ERROR_MESSAGE =
   'PAGE_UNLOADED_DURING_EXECUTION: Critical css generation script could not be executed.\n\nThis most often happens when the page is navigated away from after load, f.e. window.location or via a meta tag refresh directive. For the critical css generation to work the loaded page must stay: remove any redirects or move them to the server. You can also disable them on your end just for the critical css generation, f.e. via a query parameter.'
 
 function blockinterceptedRequests (interceptedRequest) {

--- a/src/core.js
+++ b/src/core.js
@@ -8,6 +8,9 @@ import nonMatchingMediaQueryRemover from './non-matching-media-query-remover'
 
 const debuglog = debug('penthouse:core')
 
+const PAGE_UNLOADED_DURING_EXECUTION_ERROR_MESSAGE =
+  'PAGE_UNLOADED_DURING_EXECUTION: Critical css generation script could not be executed.\n\nThis most often happens when the page is navigated away from after load, f.e. window.location or via a meta tag refresh directive. For the critical css generation to work the loaded page must stay: remove any redirects or move them to the server. You can also disable them on your end just for the critical css generation, f.e. via a query parameter.'
+
 function blockinterceptedRequests (interceptedRequest) {
   const isJsRequest = /\.js(\?.*)?$/.test(interceptedRequest.url)
   if (isJsRequest) {
@@ -345,7 +348,14 @@ async function pruneNonCriticalCssLauncher ({
         })
     } catch (err) {
       debuglog('pruneNonCriticalSelector threw an error: ' + err)
-      cleanupAndExit({ error: err })
+      const errorDueToPageUnloaded = /Cannot find context with specified id undefined/.test(
+        err
+      )
+      cleanupAndExit({
+        error: errorDueToPageUnloaded
+          ? new Error(PAGE_UNLOADED_DURING_EXECUTION_ERROR_MESSAGE)
+          : err
+      })
       return
     }
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -3,6 +3,8 @@ import penthouse from '../lib/'
 import { readFileSync as read } from 'fs'
 import normaliseCss from './util/normaliseCss'
 
+import { PAGE_UNLOADED_DURING_EXECUTION_ERROR_MESSAGE } from '../lib/core'
+
 describe('penthouse core tests', () => {
   function staticServerFileUrl (file) {
     return 'file://' + path.join(process.env.PWD, 'test', 'static-server', file)
@@ -187,6 +189,25 @@ describe('penthouse core tests', () => {
     })
       .then(result => {
         expect(result.trim()).toBe('')
+      })
+  })
+
+  it('should throw explicit error if page unloads during critical css generation', done => {
+    return penthouse({
+      url: staticServerFileUrl('infinite-page-refresh.html'),
+      cssString: '.doesNotMatterHere {}',
+      width: 800,
+      height: 450
+    })
+      .then(() => {
+        done(new Error('did not throw explicit page unload error'))
+      })
+      .catch(err => {
+        if (err.message === PAGE_UNLOADED_DURING_EXECUTION_ERROR_MESSAGE) {
+          done()
+        } else {
+          done(new Error('did not throw explicit page unload error, but instead: ' + err))
+        }
       })
   })
 })

--- a/test/static-server/infinite-page-refresh.html
+++ b/test/static-server/infinite-page-refresh.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+
+<head>
+    <title>https://example.com/</title>
+    <link rel="canonical" href="https://example.com/" />
+    <meta name="robots" content="noindex">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <!--
+    The next meta makes critical (or puppeteer) throw:
+    Protocol error (Runtime.callFunctionOn): Cannot find context with specified id undefined
+    -->
+    <meta http-equiv="refresh" content="0" />
+</head>
+
+</html>


### PR DESCRIPTION
Resolves https://github.com/pocketjoso/penthouse/issues/263

Now Penthouse will thrown an if the page unloads (is navigated away from) during critical css generation. The error is:

> PAGE_UNLOADED_DURING_EXECUTION: Critical css generation script could not be executed.
>
> This most often happens when the page is navigated away from after load, f.e. window.location or via a meta tag refresh directive. For the critical css generation to work the loaded page must stay: remove any redirects or move them to the server. You can also disable them on your end just for the critical css generation, f.e. via a query parameter.