### PR TITLE
Reuse browser pages

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,138 @@
+import puppeteer from 'puppeteer'
+import debug from 'debug'
+
+const debuglog = debug('penthouse:browser')
+
+// shared between penthouse calls
+let browser = null
+let _browserLaunchPromise = null
+// browser.pages is not implemented, so need to count myself to not close browser
+// until all pages used by penthouse are closed (i.e. individual calls are done)
+let _browserPagesOpen = 0
+
+const DEFAULT_PUPPETEER_LAUNCH_ARGS = [
+  '--disable-setuid-sandbox',
+  '--no-sandbox',
+  '--ignore-certificate-errors'
+  // better for Docker:
+  // https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#tips
+  // (however caused memory leaks in Penthouse when testing in Ubuntu, hence disabled)
+  // '--disable-dev-shm-usage'
+]
+
+export async function launchBrowserIfNeeded ({ getBrowser, width, height }) {
+  if (browser) {
+    return
+  }
+  if (
+    getBrowser &&
+    typeof getBrowser === 'function' &&
+    !_browserLaunchPromise
+  ) {
+    _browserLaunchPromise = getBrowser()
+  }
+  if (!_browserLaunchPromise) {
+    debuglog('no browser instance, launching new browser..')
+
+    _browserLaunchPromise = puppeteer
+      .launch({
+        ignoreHTTPSErrors: true,
+        args: DEFAULT_PUPPETEER_LAUNCH_ARGS,
+        defaultViewport: {
+          width,
+          height
+        }
+      })
+      .then(browser => {
+        debuglog('new browser launched')
+        return browser
+      })
+  }
+  browser = await _browserLaunchPromise
+  _browserLaunchPromise = null
+}
+
+export async function closeBrowser ({ unstableKeepBrowserAlive }) {
+  debuglog('closeBrowser')
+  if (browser && !unstableKeepBrowserAlive) {
+    if (_browserPagesOpen > 0) {
+      debuglog(
+        'keeping browser open as _browserPagesOpen: ' + _browserPagesOpen
+      )
+    } else if (browser && browser.close) {
+      browser.close()
+      browser = null
+      _browserLaunchPromise = null
+      debuglog('closed browser')
+    }
+  }
+}
+
+export async function restartBrowser ({ getBrowser, width, height }) {
+  debuglog(
+    'restartBrowser called' + '\n_browserPagesOpen: ' + (_browserPagesOpen + 1)
+  )
+  // for some reason Chromium is no longer opened;
+  // perhaps it crashed
+  if (_browserLaunchPromise) {
+    // in this case the browser is already restarting
+    await _browserLaunchPromise
+    // if getBrowser is specified the user is managing the puppeteer browser themselves,
+    // so we do nothing.
+  } else if (!getBrowser) {
+    console.log('now restarting chrome after crash')
+    browser = null
+    await launchBrowserIfNeeded({ width, height })
+  }
+}
+
+export async function browserIsRunning () {
+  try {
+    // will throw 'Not opened' error if browser is not running
+    await browser.version()
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+export async function getOpenBrowserPage ({ unstableKeepBrowserAlive }) {
+  // TODO: in unstableKeepBrowserAlive, start reusing browser pages.
+  // avoids repeated cost of page open/close
+  _browserPagesOpen++
+  debuglog(
+    'adding browser page for generateCriticalCss, now: ' + _browserPagesOpen
+  )
+  return browser.newPage()
+}
+
+export async function closeBrowserPage ({
+  page,
+  error,
+  unstableKeepBrowserAlive
+}) {
+  // page.close will error if page/browser has already been closed;
+  // try to avoid
+  _browserPagesOpen--
+  debuglog(
+    'remove browser page for generateCriticalCss, now: ' + _browserPagesOpen
+  )
+
+  if (page && !(error && error.toString().indexOf('Target closed') > -1)) {
+    debuglog('cleanupAndExit -> try to close browser page')
+    // Without try/catch if error penthouse will crash if error here,
+    // and wont restart properly
+    try {
+      // must await here, otherwise will receive errors if closing
+      // browser before page is properly closed,
+      // however in unstableKeepBrowserAlive browser is never closed by penthouse.
+      if (unstableKeepBrowserAlive) {
+        page.close()
+      } else {
+        await page.close()
+      }
+    } catch (err) {
+      debuglog('cleanupAndExit -> failed to close browser page (ignoring)')
+    }
+  }
+}

--- a/src/core.js
+++ b/src/core.js
@@ -86,18 +86,17 @@ async function astFromCss ({ cssString, strict }) {
 
 async function preparePage ({
   page,
+  pagePromise,
   width,
   height,
-  browser,
   userAgent,
   customPageHeaders,
   blockJSRequests,
   cleanupAndExit,
   getHasExited
 }) {
-  debuglog('preparePage START')
   try {
-    page = await browser.newPage()
+    page = await pagePromise
   } catch (e) {
     if (getHasExited()) {
       // we already exited (strict mode css parsing erros)
@@ -107,7 +106,7 @@ async function preparePage ({
     }
     return
   }
-  debuglog('new page opened in browser')
+  debuglog('open page ready in browser')
 
   // We set the viewport size in the browser when it launches,
   // and then re-use it for each page (to avoid extra work).
@@ -195,7 +194,7 @@ async function grabPageScreenshot ({
 }
 
 async function pruneNonCriticalCssLauncher ({
-  browser,
+  pagePromise,
   url,
   cssString,
   width,
@@ -269,9 +268,9 @@ async function pruneNonCriticalCssLauncher ({
     // 1. start preparing a browser page (tab) [NOT BLOCKING]
     const updatedPagePromise = preparePage({
       page,
+      pagePromise,
       width,
       height,
-      browser,
       userAgent,
       customPageHeaders,
       blockJSRequests,

--- a/src/core.js
+++ b/src/core.js
@@ -95,8 +95,11 @@ async function preparePage ({
   cleanupAndExit,
   getHasExited
 }) {
+  let reusedPage
   try {
-    page = await pagePromise
+    const pagePromiseResult = await pagePromise
+    page = pagePromiseResult.page
+    reusedPage = pagePromiseResult.reused
   } catch (e) {
     debuglog('unexpected: could not get an open browser page' + e)
     return
@@ -133,6 +136,18 @@ async function preparePage ({
     } catch (e) {
       debuglog('failed setting extra http headers: ' + e)
     }
+  }
+
+  // assumes the page was already configured from previous call!
+  if (reusedPage) {
+    return Promise.all([
+      setViewportPromise,
+      setUserAgentPromise,
+      setCustomPageHeadersPromise
+    ]).then(() => {
+      debuglog('preparePage DONE')
+      return page
+    })
   }
 
   let blockJSRequestsPromise

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const DEFAULT_PROPERTIES_TO_REMOVE = [
 ]
 
 function exitHandler () {
-  closeBrowser()
+  closeBrowser({ forceClose: true })
   process.exit(0)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -134,8 +134,9 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
         unstableKeepBrowserAlive: options.unstableKeepBrowserAlive
       })
     } catch (e) {
+      const page = await pagePromise.then(({ page }) => page)
       await closeBrowserPage({
-        page: await pagePromise,
+        page,
         error: e,
         unstableKeepBrowserAlive: options.unstableKeepBrowserAlive
       })
@@ -166,8 +167,9 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
       return
     }
 
+    const page = await pagePromise.then(({ page }) => page)
     await closeBrowserPage({
-      page: await pagePromise,
+      page,
       unstableKeepBrowserAlive: options.unstableKeepBrowserAlive
     })
 

--- a/src/index.js
+++ b/src/index.js
@@ -152,12 +152,16 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
     debuglog('call generateCriticalCssWrapped')
     let formattedCss
     try {
+      // TODO: in unstableKeepBrowserAlive, start reusing browser pages.
+      // avoids repeated cost of page open/close
+      const pagePromise = browser.newPage()
       _browserPagesOpen++
       debuglog(
         'adding browser page for generateCriticalCss, now: ' + _browserPagesOpen
       )
+
       formattedCss = await generateCriticalCss({
-        browser,
+        pagePromise,
         url: options.url,
         cssString: options.cssString,
         width,


### PR DESCRIPTION
- now using puppeteer to count how many pages are being used in the browser, to know when it's safe to close it.
- puppeteer launches chrome with one open page (tab) - re-use it.
- in `unstableKeepBrowserAlive` mode, keep re-using browser pages.

Also cleaned up some code.