### PR TITLE
Timeout fixes

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -14,7 +14,10 @@ const _UNSTABLE_KEEP_ALIVE_MAX_KEPT_OPEN_PAGES = 4
 const DEFAULT_PUPPETEER_LAUNCH_ARGS = [
   '--disable-setuid-sandbox',
   '--no-sandbox',
-  '--ignore-certificate-errors'
+  '--ignore-certificate-errors',
+  // workaround for issues when using ignoreHTTPSErrors and Page.setRequestInterception:
+  // https://github.com/GoogleChrome/puppeteer/issues/3118#issuecomment-417754246
+  '--enable-features=NetworkService'
   // better for Docker:
   // https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#tips
   // (however caused memory leaks in Penthouse when testing in Ubuntu, hence disabled)
@@ -34,8 +37,8 @@ export async function launchBrowserIfNeeded ({ getBrowser, width, height }) {
     debuglog('no browser instance, launching new browser..')
 
     _browserLaunchPromise = puppeteer.launch({
-      ignoreHTTPSErrors: true,
       args: DEFAULT_PUPPETEER_LAUNCH_ARGS,
+      ignoreHTTPSErrors: true,
       defaultViewport: {
         width,
         height

--- a/src/browser.js
+++ b/src/browser.js
@@ -174,6 +174,17 @@ export async function closeBrowserPage ({
           page.close()
         } else {
           debuglog('saving page for re-use, instead of closing')
+          if (error) {
+            // When a penthouse job execution errors,
+            // in some conditions when later re-use the page
+            // certain methods don't work,
+            // such as Page.setUserAgent never resolving.
+            // "resetting" the page by navigation to about:blank first fixes this.
+            debuglog('Reset page first..')
+            await page.goto('about:blank').then(() => {
+              debuglog('... page reset DONE')
+            })
+          }
           reusableBrowserPages.push(page)
         }
       } else {

--- a/src/core.js
+++ b/src/core.js
@@ -356,6 +356,10 @@ async function pruneNonCriticalCssLauncher ({
     // -> [BLOCK FOR] renderWaitTime
     await renderWaitPromise
 
+    if (getHasExited()) {
+      return
+    }
+
     // -> [BLOCK FOR] critical css selector pruning (in browser)
     let criticalSelectors
     try {
@@ -379,6 +383,9 @@ async function pruneNonCriticalCssLauncher ({
           ? new Error(PAGE_UNLOADED_DURING_EXECUTION_ERROR_MESSAGE)
           : err
       })
+      return
+    }
+    if (getHasExited()) {
       return
     }
 

--- a/src/core.js
+++ b/src/core.js
@@ -23,15 +23,13 @@ function blockinterceptedRequests (interceptedRequest) {
 
 function loadPage (page, url, timeout, pageLoadSkipTimeout) {
   debuglog('page load start')
-  // set a higher number than the timeout option, in order to make
-  // puppeteer’s timeout _never_ happen
   let waitingForPageLoad = true
-  let loadPagePromise = page.goto(url, { timeout: timeout + 1000 })
+  let loadPagePromise = page.goto(url)
   if (pageLoadSkipTimeout) {
     loadPagePromise = Promise.race([
       loadPagePromise,
       new Promise(resolve => {
-        // instead we manually _abort_ page load after X time,
+        // _abort_ page load after X time,
         // in order to deal with spammy pages that keep sending non-critical requests
         // (tracking etc), which would otherwise never load.
         // With JS disabled it just shouldn't take that many seconds to load what's needed
@@ -149,6 +147,9 @@ async function preparePage ({
       return page
     })
   }
+  // disable Puppeteer navigation timeouts;
+  // Penthouse tracks these internally instead.
+  page.setDefaultNavigationTimeout(0)
 
   let blockJSRequestsPromise
   if (blockJSRequests) {

--- a/src/core.js
+++ b/src/core.js
@@ -113,7 +113,7 @@ async function preparePage ({
   // and then re-use it for each page (to avoid extra work).
   // Only if later pages use a different viewport size do we need to
   // update it here.
-  let setViewportPromise = Promise.resolve
+  let setViewportPromise = Promise.resolve()
   const currentViewport = page.viewport()
   if (currentViewport.width !== width || currentViewport.height !== height) {
     setViewportPromise = page
@@ -125,7 +125,7 @@ async function preparePage ({
     .setUserAgent(userAgent)
     .then(() => debuglog('userAgent set'))
 
-  let setCustomPageHeadersPromise
+  let setCustomPageHeadersPromise = Promise.resolve()
   if (customPageHeaders) {
     try {
       setCustomPageHeadersPromise = page


### PR DESCRIPTION
Since Penthouse@1.8 there has been more penthouse timeouts. I traced this puppeteer never firing the load event for sites with https errors. Eventually I got a tip on a workaround for this (https://github.com/GoogleChrome/puppeteer/issues/3118#issuecomment-417754246), so should work better now. This workaround should also resolve the blocker for upgrading puppeteer (to 1.7), but I will test that later - one thing at the time.