### PR TITLE
Cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Only `url` and `cssString` are required - all other options are optional.
 | maxElementsToCheckPerSelector | `integer` | `undefined` | Can be specified to limit nr of elements to inspect per css selector, reducing execution time.
 | userAgent | `string` | `'Penthouse Critical Path CSS Generator'` | specify which user agent string when loading the page |
 | customPageHeaders | `object` | | Set extra http headers to be sent with the request for the url. |
+| cookies | `array` | `[]` | For formatting of each cookie, see [Puppeteer setCookie docs](https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#pagesetcookiecookies) |
 | strict | `boolean` | `false` | Make Penthouse throw on errors parsing the original CSS. Legacy option, not recommended. |
 
 ## Troubleshooting

--- a/src/browser.js
+++ b/src/browser.js
@@ -172,7 +172,13 @@ export async function closeBrowserPage ({
   )
 
   const badErrors = ['Target closed', 'Page crashed']
-  if (page && !(error && badErrors.some(badError => error.toString().indexOf(badError) > -1))) {
+  if (
+    page &&
+    !(
+      error &&
+      badErrors.some(badError => error.toString().indexOf(badError) > -1)
+    )
+  ) {
     // Without try/catch if error penthouse will crash if error here,
     // and wont restart properly
     try {

--- a/src/browser.js
+++ b/src/browser.js
@@ -171,7 +171,8 @@ export async function closeBrowserPage ({
       browserPages.length
   )
 
-  if (page && !(error && error.toString().indexOf('Target closed') > -1)) {
+  const badErrors = ['Target closed', 'Page crashed']
+  if (page && !(error && badErrors.some(badError => error.toString().indexOf(badError) > -1))) {
     // Without try/catch if error penthouse will crash if error here,
     // and wont restart properly
     try {

--- a/src/core.js
+++ b/src/core.js
@@ -165,7 +165,7 @@ async function preparePage ({
   }
 
   page.on('error', error => {
-    debuglog('page crashed: ' + error)
+    debuglog('page error: ' + error)
     cleanupAndExit({ error })
   })
   page.on('console', msg => {
@@ -327,6 +327,7 @@ async function pruneNonCriticalCssLauncher ({
       cleanupAndExit({ error: new Error('Page load timed out') })
       return
     }
+    if (_hasExited) return
 
     // Penthouse waits for the `load` event to fire
     // (before loadPagePromise resolves; except for very slow loading pages)

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,7 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
             ? options.blockJSRequests
             : DEFAULT_BLOCK_JS_REQUESTS,
         customPageHeaders: options.customPageHeaders,
+        cookies: options.cookies,
         screenshots: options.screenshots,
         keepLargerMediaQueries: options.keepLargerMediaQueries,
         maxElementsToCheckPerSelector: options.maxElementsToCheckPerSelector,


### PR DESCRIPTION
Cookies can now be set in Penthouse, which allows for more reliable critical css generation for logged in pages. Even though first render times are much more important for first time visitors, i.e. pages that don't require authentication, it can make sense to speed it up also for logged in pages. Authentication could in part be handled before via `customPageHeaders`, but setting cookies simplifies things, f.e. in cases of server redirects dropping headers.

The cookies are passed through to Puppeteer, and follows their formatting:
https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#pagesetcookiecookies

```js
penthouse({
url,
cssString,
cookies: [{
  name,     // <string> required
  value,    // <string> required
  url,      // <string>
  domain,   // <string>
  path,     // <string>
  expires,  // <number> Unix time in seconds.
  httpOnly, // <boolean>
  secure,   // <boolean>
  sameSite  // <string>
}]
```