### PR TITLE
internal job counter determining if should close browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,9 @@ import {
   restartBrowser,
   browserIsRunning,
   getOpenBrowserPage,
-  closeBrowserPage
+  closeBrowserPage,
+  addJob,
+  removeJob
 } from './browser'
 
 const debuglog = debug('penthouse')
@@ -178,10 +180,12 @@ module.exports = function (options, callback) {
   process.on('SIGINT', exitHandler)
 
   return new Promise(async (resolve, reject) => {
+    addJob()
     function cleanupAndExit ({ returnValue, error = null }) {
       process.removeListener('exit', exitHandler)
       process.removeListener('SIGTERM', exitHandler)
       process.removeListener('SIGINT', exitHandler)
+      removeJob()
 
       closeBrowser({
         unstableKeepBrowserAlive: options.unstableKeepBrowserAlive


### PR DESCRIPTION
The previous logic could lead to race conditions; the browser instance a later penthouse call was relying on could be closed by an earlier penthouse execution. This PR fixes that. This logic has had bugs before in certain edge cases so I will leave this PR open for a while and do further tests before merging. I will publish a release candidate of it.