### PR TITLE
#284: throw an error on server error response

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Only `url` and `cssString` are required - all other options are optional. Note t
 | customPageHeaders | `object` | | Set extra http headers to be sent with the request for the url. |
 | cookies | `array` | `[]` | For formatting of each cookie, see [Puppeteer setCookie docs](https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#pagesetcookiecookies) |
 | strict | `boolean` | `false` | Make Penthouse throw on errors parsing the original CSS. Legacy option, not recommended. |
+| allowedResponseCode | <code>number&#124;regex&#124;function</code> | | Let Penthouse stop if the server response code is not matching this value. `number` and `regex` types are tested against the [response.status()](https://github.com/GoogleChrome/puppeteer/blob/v1.14.0/docs/api.md#responsestatus). A `function` is also allowed and gets [Response](https://github.com/GoogleChrome/puppeteer/blob/v1.14.0/docs/api.md#class-response) as argument. The function should return a `boolean`.|
 
 ## Troubleshooting
 

--- a/src/core.js
+++ b/src/core.js
@@ -47,10 +47,17 @@ function loadPage (page, url, timeout, pageLoadSkipTimeout) {
       })
     ])
   }
-  return loadPagePromise.then(() => {
+  return loadPagePromise.then(response => {
+    checkResponseStatus(response)
     waitingForPageLoad = false
     debuglog('page load DONE')
   })
+}
+
+function checkResponseStatus (response) {
+  if (!response.ok()) {
+    throw new Error(`Server response status: ${response.status()}`)
+  }
 }
 
 function setupBlockJsRequests (page) {

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,8 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
             ? options.maxEmbeddedBase64Length
             : DEFAULT_MAX_EMBEDDED_BASE64_LENGTH,
         debuglog,
-        unstableKeepBrowserAlive: options.unstableKeepBrowserAlive
+        unstableKeepBrowserAlive: options.unstableKeepBrowserAlive,
+        allowedResponseCode: options.allowedResponseCode
       })
     } catch (e) {
       const page = await pagePromise.then(({ page }) => page)

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -15,7 +15,7 @@ function staticServerFileUrl (file) {
   return 'file://' + path.join(process.env.PWD, 'test', 'static-server', file)
 }
 
-function responseSatusUrl (code) {
+function responseStatusUrl (code) {
   return 'http://localhost:' + serverPort + '?responseStatus=' + code
 }
 
@@ -156,7 +156,7 @@ describe('basic tests of penthouse functionality', () => {
 
   it('should not throw an error on 200-299 response status', done => {
     penthouse({
-      url: responseSatusUrl(200),
+      url: responseStatusUrl(200),
       css: page1cssPath
     }).then(() => {
       done();
@@ -170,7 +170,7 @@ describe('basic tests of penthouse functionality', () => {
     var errorMessage = 'Didn\'t throw an error on ' + code + ' response';
 
     penthouse({
-      url: responseSatusUrl(code),
+      url: responseStatusUrl(code),
       css: page1cssPath
     }).then(() => {
         done(new Error(errorMessage))

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -4,17 +4,39 @@ import path from 'path'
 import penthouse from '../lib/'
 import { readFileSync as read } from 'fs'
 import csstree from 'css-tree'
+import http from 'http'
+import url from 'url'
 
 import normaliseCss from './util/normaliseCss'
+
+const serverPort = 8888;
 
 function staticServerFileUrl (file) {
   return 'file://' + path.join(process.env.PWD, 'test', 'static-server', file)
 }
 
+function responseSatusUrl (code) {
+  return 'http://localhost:' + serverPort + '?responseStatus=' + code
+}
+
+
 describe('basic tests of penthouse functionality', () => {
   var page1FileUrl = staticServerFileUrl('page1.html')
   var page1cssPath = path.join(process.env.PWD, 'test', 'static-server', 'page1.css')
   var originalCss = read(page1cssPath).toString()
+  var httpServer;
+
+  beforeAll(function() {
+    httpServer = http.createServer(function(request, response) {
+      var query = url.parse(request.url, true).query
+      response.writeHead(query.responseStatus)
+      response.end()
+    }).listen(serverPort)
+  });
+
+  afterAll(function() {
+    httpServer.close();
+  })
 
   function largeViewportTest () {
     var widthLargerThanTotalTestCSS = 1000
@@ -131,4 +153,33 @@ describe('basic tests of penthouse functionality', () => {
         }
       })
   })
+
+  it('should not throw an error on 200-299 response status', done => {
+    penthouse({
+      url: responseSatusUrl(200),
+      css: page1cssPath
+    }).then(() => {
+      done();
+    }).catch(() => {
+      done(new Error('Thrown an error on a 200-299 response status'))
+    })
+  });
+
+  it('should throw an error on error server response', done => {
+    var code = 401;
+    var errorMessage = 'Didn\'t throw an error on ' + code + ' response';
+
+    penthouse({
+      url: responseSatusUrl(code),
+      css: page1cssPath
+    }).then(() => {
+        done(new Error(errorMessage))
+    }).catch((err) => {
+      if (err.message.match(code)) {
+        done()
+      } else {
+        done(new Error(errorMessage))
+      }
+    })
+  });
 })


### PR DESCRIPTION
Penthouse isn't stopping nor is throwing an error when the server is responding with an error status code. With this change only 200-299 response status codes will let penthouse proceed.