### PR TITLE
Properly test min-max media queries for critical CSS inclusion

### DIFF
--- a/src/non-matching-media-query-remover.js
+++ b/src/non-matching-media-query-remover.js
@@ -8,7 +8,7 @@ const debuglog = debug('penthouse:preformatting:nonMatchingMediaQueryRemover')
 //  - @print
 //  - min-width > width OR min-height > height
 //    (the latter only if !keepLargerMediaQueries -- which is the default)
-//  - min-width > width AND max-width < width
+//  - min-width > width AND max-width > width
 function _isMatchingMediaQuery (mediaQuery, matchConfig) {
   // TODO: use the media query parsing from css-tree instead
   let mediaAST

--- a/src/non-matching-media-query-remover.js
+++ b/src/non-matching-media-query-remover.js
@@ -7,8 +7,13 @@ const debuglog = debug('penthouse:preformatting:nonMatchingMediaQueryRemover')
 // only filters out:
 //  - @print
 //  - min-width > width OR min-height > height
-// and the latter only if !keepLargerMediaQueries (which is the default)
-function _isMatchingMediaQuery (mediaQuery, matchConfig) {
+//    (the latter only if !keepLargerMediaQueries -- which is the default)
+//  - min-width > width AND max-width < width
+function _isMatchingMediaQuery (
+  mediaQuery,
+  matchConfig,
+  keepLargerMediaQueries
+) {
   // TODO: use the media query parsing from css-tree instead
   let mediaAST
   try {
@@ -35,16 +40,39 @@ function _isMatchingMediaQuery (mediaQuery, matchConfig) {
     if (mq.expressions.length === 0) {
       return true
     }
-    return mq.expressions.some(function ({ modifier, feature, value }) {
-      if (modifier === 'min') {
-        const constructedQuery = `${
-          isInverse ? 'not ' : ''
-        }(min-${feature}: ${value})`
-        return cssMediaQuery.match(constructedQuery, matchConfig)
-      } else {
-        return true
-      }
-    })
+
+    // shortcut for keepLargerMediaQueries option
+    if (keepLargerMediaQueries) {
+      return true
+    }
+
+    /*
+    costructing the test to match against the mediaquery
+    if the mediaquery (mq) has "AND" conditions, mq.expressions is an array of feature objects { modifier, feature, value }
+      mq.expressions.length > 1
+    if the mediaquery (mq) has "OR"  conditions, the mediaquery is split in _n_ mq objects,
+      each having an expressions array of 1 feature objects { modifier, feature, value }
+    */
+    if (mq.expressions.length > 1) {
+      const constructedQuery = mq.expressions
+        .map(
+          ({ modifier, feature, value }) =>
+            `${isInverse ? 'not ' : ''}(${modifier}-${feature}: ${value})`
+        )
+        .join(' and ')
+      return cssMediaQuery.match(constructedQuery, matchConfig)
+    } else {
+      return mq.expressions.some(function ({ modifier, feature, value }) {
+        if (modifier === 'min') {
+          const constructedQuery = `${
+            isInverse ? 'not ' : ''
+          }(min-${feature}: ${value})`
+          return cssMediaQuery.match(constructedQuery, matchConfig)
+        } else {
+          return true
+        }
+      })
+    }
   })
 
   return keep
@@ -54,15 +82,21 @@ function nonMatchingMediaQueryRemover (
   ast,
   width,
   height,
-  keepLargerMediaQueries
+  keepLargerMediaQueries = false
 ) {
   debuglog('BEFORE')
   const matchConfig = {
     type: 'screen',
-    width: (keepLargerMediaQueries ? 9999999999 : width) + 'px',
-    height: (keepLargerMediaQueries ? 9999999999 : height) + 'px'
+    width: width + 'px',
+    height: height + 'px'
   }
-  debuglog('matchConfig: ' + JSON.stringify(matchConfig, null, 2))
+  debuglog(
+    'matchConfig: ' +
+      JSON.stringify(matchConfig, null, 2) +
+      '\n' +
+      'keepLargerMediaQueries: ' +
+      keepLargerMediaQueries
+  )
 
   csstree.walk(ast, {
     visit: 'Atrule',
@@ -77,10 +111,18 @@ function nonMatchingMediaQueryRemover (
         return
       }
       const mediaQuery = csstree.generate(atrule.prelude)
-      const isMatching = _isMatchingMediaQuery(mediaQuery, matchConfig)
+      // ismatching true when mq must be kept
+      // if keep larger mq, keep if matching OR matching matchKeepLargeConfig
+      const isMatching = _isMatchingMediaQuery(
+        mediaQuery,
+        matchConfig,
+        keepLargerMediaQueries
+      )
       if (!isMatching) {
         debuglog('DROP: ' + `(${mediaQuery}), `)
         list.remove(item)
+      } else {
+        debuglog('KEEP: ' + `(${mediaQuery}), `)
       }
     }
   })

--- a/test/pre-formatting.test.js
+++ b/test/pre-formatting.test.js
@@ -91,11 +91,11 @@ describe('penthouse pre formatting tests', () => {
         remove: false
       }
     ]
-    // const largeErrors = testMediaQueryRemoval(largeTest, 1600, 1200)
-    // if (largeErrors.length) {
-    //   done(new Error('largeErrors:\n' + largeErrors.join('\n')))
-    //   return
-    // }
+    const largeErrors = testMediaQueryRemoval(largeTest, 1600, 1200)
+    if (largeErrors.length) {
+      done(new Error('largeErrors:\n' + largeErrors.join('\n')))
+      return
+    }
 
     // test keepLargeMediaQueries - to be moved
     const keepLargeMediaQueriesTest = [
@@ -108,11 +108,11 @@ describe('penthouse pre formatting tests', () => {
         remove: false
       }
     ]
-    // let keepLargeMediaQueriesErrors = testMediaQueryRemoval(keepLargeMediaQueriesTest, 1300, 900, true)
-    // if (keepLargeMediaQueriesErrors.length) {
-    //   done(new Error('keepLargeMediaQueriesErrors:\n' + keepLargeMediaQueriesErrors.join('\n')))
-    //   return
-    // }
+    let keepLargeMediaQueriesErrors = testMediaQueryRemoval(keepLargeMediaQueriesTest, 1300, 900, true)
+    if (keepLargeMediaQueriesErrors.length) {
+      done(new Error('keepLargeMediaQueriesErrors:\n' + keepLargeMediaQueriesErrors.join('\n')))
+      return
+    }
 
     done()
   })

--- a/test/pre-formatting.test.js
+++ b/test/pre-formatting.test.js
@@ -33,13 +33,13 @@ describe('penthouse pre formatting tests', () => {
       `@media oiasjdoiasd {}`,
       // covering combined queries
       `@media (min-width: 320px) and (max-width: 400px) {}`,
-      `@media (min-width: 150px) and (max-width: 1700px) {}`,
+      `@media (min-width: 150px) and (max-width: 1700px) {}`
     ]
     // 1300, 1600
     const mediaToRemoveAlways = [
       `@media print {}`,
       `@media not screen {}`,
-      `@media not (min-width: 1px) {}`,
+      `@media not (min-width: 1px) {}`
     ]
     // 1600
     const mediaToRemoveUnlessLarge = [
@@ -48,12 +48,12 @@ describe('penthouse pre formatting tests', () => {
       `@media screen and (min-width: 93.75rem) {}`,
       // covering combined queries
       `@media (min-width: 1500px) and (max-width: 1700px) {}`,
-      `@media screen and (min-width: 1500px) and (max-width: 1800px) {}`,
+      `@media screen and (min-width: 1500px) and (max-width: 1800px) {}`
     ]
     const mediaToRemoveUnlessKeepLarge = [
       `@media (min-width: 99999px) {}`,
       // covering combined queries
-      `@media (min-width: 1800px) and (max-width: 2800px) {}`,
+      `@media (min-width: 1800px) and (max-width: 2800px) {}`
     ]
 
     // test default settings

--- a/test/pre-formatting.test.js
+++ b/test/pre-formatting.test.js
@@ -26,23 +26,34 @@ process.setMaxListeners(0)
 
 describe('penthouse pre formatting tests', () => {
   it('should remove non matching media queries', done => {
+    // 1300, 1600
     const mediaToAlwaysKeep = [
       `@media all {}`,
       // going for false positives over false negatives
-      `@media oiasjdoiasd {}`
+      `@media oiasjdoiasd {}`,
+      // covering combined queries
+      `@media (min-width: 320px) and (max-width: 400px) {}`,
+      `@media (min-width: 150px) and (max-width: 1700px) {}`,
     ]
+    // 1300, 1600
     const mediaToRemoveAlways = [
       `@media print {}`,
       `@media not screen {}`,
-      `@media not (min-width: 1px) {}`
+      `@media not (min-width: 1px) {}`,
     ]
+    // 1600
     const mediaToRemoveUnlessLarge = [
       `@media (min-width: 1500px) {}`,
       `@media screen and (min-width: 93.75em) {}`,
-      `@media screen and (min-width: 93.75rem) {}`
+      `@media screen and (min-width: 93.75rem) {}`,
+      // covering combined queries
+      `@media (min-width: 1500px) and (max-width: 1700px) {}`,
+      `@media screen and (min-width: 1500px) and (max-width: 1800px) {}`,
     ]
     const mediaToRemoveUnlessKeepLarge = [
-      `@media (min-width: 99999px) {}`
+      `@media (min-width: 99999px) {}`,
+      // covering combined queries
+      `@media (min-width: 1800px) and (max-width: 2800px) {}`,
     ]
 
     // test default settings
@@ -80,11 +91,11 @@ describe('penthouse pre formatting tests', () => {
         remove: false
       }
     ]
-    const largeErrors = testMediaQueryRemoval(largeTest, 1600, 1200)
-    if (largeErrors.length) {
-      done(new Error('largeErrors:\n' + largeErrors.join('\n')))
-      return
-    }
+    // const largeErrors = testMediaQueryRemoval(largeTest, 1600, 1200)
+    // if (largeErrors.length) {
+    //   done(new Error('largeErrors:\n' + largeErrors.join('\n')))
+    //   return
+    // }
 
     // test keepLargeMediaQueries - to be moved
     const keepLargeMediaQueriesTest = [
@@ -97,11 +108,11 @@ describe('penthouse pre formatting tests', () => {
         remove: false
       }
     ]
-    let keepLargeMediaQueriesErrors = testMediaQueryRemoval(keepLargeMediaQueriesTest, 1300, 900, true)
-    if (keepLargeMediaQueriesErrors.length) {
-      done(new Error('keepLargeMediaQueriesErrors:\n' + keepLargeMediaQueriesErrors.join('\n')))
-      return
-    }
+    // let keepLargeMediaQueriesErrors = testMediaQueryRemoval(keepLargeMediaQueriesTest, 1300, 900, true)
+    // if (keepLargeMediaQueriesErrors.length) {
+    //   done(new Error('keepLargeMediaQueriesErrors:\n' + keepLargeMediaQueriesErrors.join('\n')))
+    //   return
+    // }
 
     done()
   })


### PR DESCRIPTION
### What does this PR do
This PR allows penthouse to correctly keep or discard media queries bracketing a viewport interval, i.e. `@media (min-width: 320px) and (max-width: 650px)`.

Previously these MQs would be included in the css output even when not matching, regardless of the setting of `keepLargerMediaQueries`. For example, running penthouse at 650px would include a media query devised for tablets `(min-width: 768px) and (max-width: 1023px)`.

### What changed
We improved the logic that tests whether to keep or drop a media query by adding an explicit test for media queries using the AND operator. We also rewrote the logic for keepLargerMediaQueries by testing both against the current viewport size and the LLVP  (Ludicrously Large ViewPort) and keeping whatever is true.

All new logic is tested in `pre-formatting.test.js` where we added additional tests to cover the extra cases.

### Reason for this PR
We discovered this when extracting the critical CSS from a page in order to pass it to the AMP version, and having to tweak every bit to stay within the 50kb limit allowed. We noticed media queries for larger viewports were included even when not matching. It is highly debatable whether one should support AMP and furthermore try to fit a full-site-design CSS into an AMP page, but this PR fixes a minor inconsistency in the critical CSS output.

### title with emoji  👏👏👏👏 🚀🚀🚀🚀
penthouse is a terrific tool. we use it through Addy Osmani's critical wrapper and rely on it to improve FCP and FMP on all websites we code and all sites and projects we consult on. Thanks for providing it to all performance enthusiasts as we are (@madebymodo).