### PR TITLE
fix(browser): when usingCustomGetBrowser is set, call getBrowser each time 

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -28,15 +28,17 @@ const DEFAULT_PUPPETEER_LAUNCH_ARGS = [
 ]
 
 export async function launchBrowserIfNeeded ({ getBrowser, width, height }) {
-  if (browser) {
-    return
-  }
   const usingCustomGetBrowser = getBrowser && typeof getBrowser === 'function'
   if (usingCustomGetBrowser && !_browserLaunchPromise) {
     debuglog('using browser provided via getBrowser option')
     _browserLaunchPromise = Promise.resolve(getBrowser())
   }
   if (!_browserLaunchPromise) {
+    if (browser) {
+      // we have already a running browser
+      return
+    }
+
     debuglog('no browser instance, launching new browser..')
 
     _browserLaunchPromise = puppeteer.launch({


### PR DESCRIPTION
if using a custom browser, getBrowser is not called when "browser" is != null. As the behaviour of the browser instance is controlled outside, this leads to situation where a browser is closed, but penthouse believes the browser is still running.