### PR TITLE
interceptedRequest.url should be a function call

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -13,7 +13,7 @@ export const PAGE_UNLOADED_DURING_EXECUTION_ERROR_MESSAGE =
   'PAGE_UNLOADED_DURING_EXECUTION: Critical css generation script could not be executed.\n\nThis can happen if Penthouse was killed during execution, OR otherwise most commonly if the page navigates away after load, via setting window.location, meta tag refresh directive or similar. For the critical css generation to work the loaded page must stay: remove any redirects or move them to the server. You can also disable them on your end just for the critical css generation, for example via a query parameter.'
 
 function blockinterceptedRequests (interceptedRequest) {
-  const isJsRequest = /\.js(\?.*)?$/.test(interceptedRequest.url)
+  const isJsRequest = /\.js(\?.*)?$/.test(interceptedRequest.url())
   if (isJsRequest) {
     interceptedRequest.abort()
   } else {


### PR DESCRIPTION
👋 Hey!

I was going over a bug today related to URL interception and noticed that there's a bug in `test(interceptedRequest.url)` because `url` actually is going to return the function. To get the URL string the function should be called.

Here's an example from puppeteer documentation:
https://github.com/puppeteer/puppeteer/blob/main/new-docs/puppeteer.page.md#example-2