### PR TITLE
Ignore elements in display: none parents

### DIFF
--- a/src/browser-sandbox/pruneNonCriticalSelectors.js
+++ b/src/browser-sandbox/pruneNonCriticalSelectors.js
@@ -2,7 +2,8 @@
 // no access to scrope outside of function
 export default function pruneNonCriticalSelectors ({
   selectors,
-  maxElementsToCheckPerSelector
+  maxElementsToCheckPerSelector,
+  tryParentsDisplayNone
 }) {
   console.log('debug: pruneNonCriticalSelectors init')
   var h = window.innerHeight
@@ -23,6 +24,22 @@ export default function pruneNonCriticalSelectors ({
     var originalClearStyle = element.style.clear || ''
     element.style.clear = 'none'
     var aboveFold = element.getBoundingClientRect().top < h
+    if(aboveFold && tryParentsDisplayNone) {
+      var p = element.parentElement;
+      var parentHidden = false;
+      do {
+        //if(p.style.display === 'none') {
+        if(getComputedStyle(p).display === 'none') {
+        //if(p.getBoundingClientRect().height === 0) {
+          parentHidden = true;
+          break;
+        }
+        p = p.parentElement
+      } while (p)
+      if(parentHidden) {
+        aboveFold = false
+      }
+    }
     // cache so we dont have to re-query DOM for this value
     isElementAboveFoldCache.set(element, aboveFold)
 

--- a/src/browser-sandbox/pruneNonCriticalSelectors.js
+++ b/src/browser-sandbox/pruneNonCriticalSelectors.js
@@ -25,20 +25,18 @@ export default function pruneNonCriticalSelectors ({
     element.style.clear = 'none'
     var aboveFold = element.getBoundingClientRect().top < h
     if(aboveFold && tryParentsDisplayNone) {
-      var p = element.parentElement;
-      var parentHidden = false;
+      var current = element.parentElement;
       do {
-        //if(p.style.display === 'none') {
-        if(getComputedStyle(p).display === 'none') {
-        //if(p.getBoundingClientRect().height === 0) {
-          parentHidden = true;
+        if (isElementAboveFoldCache.has(element)) {
+          aboveFold = isElementAboveFoldCache.has(element)
           break;
         }
-        p = p.parentElement
-      } while (p)
-      if(parentHidden) {
-        aboveFold = false
-      }
+        if(getComputedStyle(current).display === 'none') {
+          aboveFold = false;
+          break;
+        }
+        current = current.parentElement
+      } while (current)
     }
     // cache so we dont have to re-query DOM for this value
     isElementAboveFoldCache.set(element, aboveFold)

--- a/src/core.js
+++ b/src/core.js
@@ -286,7 +286,8 @@ async function pruneNonCriticalCssLauncher ({
   keepLargerMediaQueries,
   maxElementsToCheckPerSelector,
   unstableKeepBrowserAlive,
-  allowedResponseCode
+  allowedResponseCode,
+  tryParentsDisplayNone
 }) {
   let _hasExited = false
   // hacky to get around _hasExited only available in the scope of this function
@@ -480,7 +481,8 @@ async function pruneNonCriticalCssLauncher ({
         .evaluate(pruneNonCriticalSelectors, {
           selectors,
           renderWaitTime,
-          maxElementsToCheckPerSelector
+          maxElementsToCheckPerSelector,
+          tryParentsDisplayNone
         })
         .then(criticalSelectors => {
           debuglog('pruneNonCriticalSelectors done')

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,8 @@ const generateCriticalCssWrapped = async function generateCriticalCssWrapped (
       allowedResponseCode: options.allowedResponseCode,
       unstableKeepOpenPages:
         options.unstableKeepOpenPages ||
-        _UNSTABLE_KEEP_ALIVE_MAX_KEPT_OPEN_PAGES
+        _UNSTABLE_KEEP_ALIVE_MAX_KEPT_OPEN_PAGES,
+      tryParentsDisplayNone: options.tryParentsDisplayNone || false
     })
   } catch (e) {
     const page = await pagePromise.then(({ page }) => page)


### PR DESCRIPTION
This PR adds ability to ignore styles for elements that are contained in hidden elements.
There is a new configuration option 'tryParentsDisplayNone' (boolean, default: false - so it doesn't change the current behavior)