### PR TITLE
fix colon escape

### DIFF
--- a/src/selectors-profile.js
+++ b/src/selectors-profile.js
@@ -78,7 +78,7 @@ function normalizeSelector (selectorNode, forceInclude, forceExclude) {
     // handle browser specific pseudo selectors bound to elements,
     // Example, button::-moz-focus-inner, input[type=number]::-webkit-inner-spin-button
     // remove browser specific pseudo and test for element
-    modifiedSelector = modifiedSelector.replace(/:?:-[a-z-]*/g, '')
+    modifiedSelector = modifiedSelector.replace(/(?<!\\):?:-[a-z-]*/g, '')
   }
 
   return modifiedSelector


### PR DESCRIPTION
Tailwind extensively uses classes that contain colons an actually are valid for css. But they need to be escaped with colon (`:`) in css. For example, I got a problem with class "xxl:-mb-24", which in css file is represented as this selector: ".xxl\:-mb-24".
