### PR TITLE
Support css @layer rules for Tailwind CSS v4

### DIFF
--- a/src/postformatting/final-rule-remover.js
+++ b/src/postformatting/final-rule-remover.js
@@ -34,7 +34,12 @@ export default function finalRuleRemover (ast, propertiesToRemove) {
 
       /* Case 3: @-rule with CSS rules inside [REMAIN] */
       // non matching media queries are stripped out in non-matching-media-query-remover.js
-      if (name === 'media' || name === 'document' || name === 'supports') {
+      if (
+        name === 'media' ||
+        name === 'document' ||
+        name === 'supports' ||
+        name === 'layer'
+      ) {
         if (atrule.block && !atrule.block.children.isEmpty()) {
           return
         }

--- a/test/static-server/at-rule-case-3--remain.css
+++ b/test/static-server/at-rule-case-3--remain.css
@@ -21,3 +21,13 @@
 		transform-origin: 5% 5%;
 	}
 }
+@layer theme {
+	:root,:host {
+		--spacing:.25rem;
+	}
+}
+@layer utilities {
+	.mx-6 {
+		margin-inline: calc(var(--spacing) * 6);
+	}
+}

--- a/test/static-server/page1.html
+++ b/test/static-server/page1.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <div id="box1">Box 1
-        <div id="box11">Box 1.1</div>
+        <div id="box11" class="mx-6">Box 1.1</div>
     </div>
     <div id="box2">Box 2
         <div id="box21">Box 2.1</div>


### PR DESCRIPTION
Tailwind CSS v4 was released, which heavily relies on modern Cascade Layers with the `@layer` property

- Tailwind CSS v4 [Designed for the modern web](https://tailwindcss.com/blog/tailwindcss-v4#designed-for-the-modern-web) — built on cutting-edge CSS features like cascade layers
- https://developer.mozilla.org/en-US/docs/Web/CSS/@layer


Sample of a generated css file using Tailwind v4:

```css
/*! tailwindcss v4.1.5 | MIT License | https://tailwindcss.com */
@layer properties {
...
}
@layer theme {
    :root, :host {
        .. all css vars go here
    }
}
@layer base {
...
}
@layer utilities {
    .text-sm {
        font-size: var(--text-sm);
        line-height: var(--tw-leading, var(--text-sm--line-height))
    }
}
```

This causes the Critical CSS for my Tailwind V4 site **to be almost completely empty**, because literally everything is wrapped inside the `@layer` property, which is not part of the safelist of penthouse, so it gets stripped out.

Given the popularity of Tailwind, could we get such fix merged in a reasonable timeframe? 🙏 